### PR TITLE
Model, team, ticket updates

### DIFF
--- a/ASI.Basecode.Data/AsiBasecodeDbContext.cs
+++ b/ASI.Basecode.Data/AsiBasecodeDbContext.cs
@@ -292,7 +292,7 @@ namespace ASI.Basecode.Data
 
                 entity.HasIndex(e => e.UserId, "IX_Feedback_UserID");
 
-                entity.HasIndex(e => e.TicketId, "UQ__Feedback__D597FD6226CBCDDA")
+                entity.HasIndex(e => e.TicketId, "UQ__Feedback__D597FD62668A4B0A")
                     .IsUnique();
 
                 entity.Property(e => e.FeedbackId)
@@ -569,6 +569,8 @@ namespace ASI.Basecode.Data
 
                 entity.HasIndex(e => e.Name, "IX_Team_Name");
 
+                entity.HasIndex(e => e.SpecializationId, "IX_Team_SpecializationID");
+
                 entity.Property(e => e.TeamId)
                     .HasMaxLength(256)
                     .HasColumnName("team_ID");
@@ -583,6 +585,17 @@ namespace ASI.Basecode.Data
                     .IsRequired()
                     .HasMaxLength(100)
                     .HasColumnName("name");
+
+                entity.Property(e => e.SpecializationId)
+                    .IsRequired()
+                    .HasMaxLength(256)
+                    .HasColumnName("specialization_ID");
+
+                entity.HasOne(d => d.Specialization)
+                    .WithMany(p => p.Teams)
+                    .HasForeignKey(d => d.SpecializationId)
+                    .OnDelete(DeleteBehavior.ClientSetNull)
+                    .HasConstraintName("FK_Team_Specialization");
             });
 
             modelBuilder.Entity<TeamMember>(entity =>
@@ -595,7 +608,7 @@ namespace ASI.Basecode.Data
 
                 entity.HasIndex(e => e.UserId, "IX_TeamMember_UserID");
 
-                entity.HasIndex(e => e.UserId, "UQ__TeamMemb__B9BF3306C9655F8C")
+                entity.HasIndex(e => e.UserId, "UQ__TeamMemb__B9BF3306D7396162")
                     .IsUnique();
 
                 entity.Property(e => e.TeamId)
@@ -730,7 +743,9 @@ namespace ASI.Basecode.Data
 
                 entity.ToTable("TicketAssignment");
 
-                entity.HasIndex(e => e.AdminId, "IX_TicketAssignment_AdminID");
+                entity.HasIndex(e => e.AgentId, "IX_TicketAssignment_AgentID");
+
+                entity.HasIndex(e => e.AssignedById, "IX_TicketAssignment_AssignedByID");
 
                 entity.HasIndex(e => e.AssignedDate, "IX_TicketAssignment_AssignedDate");
 
@@ -738,17 +753,21 @@ namespace ASI.Basecode.Data
 
                 entity.HasIndex(e => e.TicketId, "IX_TicketAssignment_TicketID");
 
-                entity.HasIndex(e => e.TicketId, "UQ__TicketAs__D597FD62A893A544")
+                entity.HasIndex(e => e.TicketId, "UQ__TicketAs__D597FD62BE17AD74")
                     .IsUnique();
 
                 entity.Property(e => e.AssignmentId)
                     .HasMaxLength(256)
                     .HasColumnName("assignment_ID");
 
-                entity.Property(e => e.AdminId)
+                entity.Property(e => e.AgentId)
+                    .HasMaxLength(256)
+                    .HasColumnName("agent_ID");
+
+                entity.Property(e => e.AssignedById)
                     .IsRequired()
                     .HasMaxLength(256)
-                    .HasColumnName("admin_ID");
+                    .HasColumnName("assignedBy_ID");
 
                 entity.Property(e => e.AssignedDate)
                     .HasColumnType("datetime")
@@ -756,7 +775,6 @@ namespace ASI.Basecode.Data
                     .HasDefaultValueSql("(getdate())");
 
                 entity.Property(e => e.TeamId)
-                    .IsRequired()
                     .HasMaxLength(256)
                     .HasColumnName("team_ID");
 
@@ -765,16 +783,20 @@ namespace ASI.Basecode.Data
                     .HasMaxLength(256)
                     .HasColumnName("ticket_ID");
 
-                entity.HasOne(d => d.Admin)
-                    .WithMany(p => p.TicketAssignments)
-                    .HasForeignKey(d => d.AdminId)
+                entity.HasOne(d => d.Agent)
+                    .WithMany(p => p.TicketAssignmentAgents)
+                    .HasForeignKey(d => d.AgentId)
+                    .HasConstraintName("FK_TicketAssignment_Agent");
+
+                entity.HasOne(d => d.AssignedBy)
+                    .WithMany(p => p.TicketAssignmentAssignedBies)
+                    .HasForeignKey(d => d.AssignedById)
                     .OnDelete(DeleteBehavior.ClientSetNull)
-                    .HasConstraintName("FK_TicketAssignment_Admin");
+                    .HasConstraintName("FK_TicketAssignment_AssignedBy");
 
                 entity.HasOne(d => d.Team)
                     .WithMany(p => p.TicketAssignments)
                     .HasForeignKey(d => d.TeamId)
-                    .OnDelete(DeleteBehavior.ClientSetNull)
                     .HasConstraintName("FK_TicketAssignment_Team");
 
                 entity.HasOne(d => d.Ticket)

--- a/ASI.Basecode.Data/Interfaces/ITicketRepository.cs
+++ b/ASI.Basecode.Data/Interfaces/ITicketRepository.cs
@@ -15,6 +15,7 @@ namespace ASI.Basecode.Data.Interfaces
         Task AddAttachmentAsync(Attachment attachment);
         Task RemoveAttachmentAsync(Attachment attachment);
         Task AssignTicketAsync(TicketAssignment assignment);
+        Task UpdateAssignmentAsync(TicketAssignment assignment);
         Task RemoveAssignmentAsync(TicketAssignment assignment);
         Task AddCommentAsync(Comment comment);
         Task UpdateCommentAsync(Comment comment);

--- a/ASI.Basecode.Data/Migrations/AddDefaultValues.Designer.cs
+++ b/ASI.Basecode.Data/Migrations/AddDefaultValues.Designer.cs
@@ -12,7 +12,7 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace ASI.Basecode.Data.Migrations
 {
     [DbContext(typeof(AsiBasecodeDbContext))]
-    [Migration("20240702041930_AddDefaultValues")]
+    [Migration("20240718093935_AddDefaultValues")]
     partial class AddDefaultValues
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
@@ -61,9 +61,13 @@ namespace ASI.Basecode.Data.Migrations
 
                     b.HasKey("ActivityId");
 
-                    b.HasIndex("TicketId");
+                    b.HasIndex(new[] { "ActivityDate" }, "IX_ActivityLog_ActivityDate");
 
-                    b.HasIndex("UserId");
+                    b.HasIndex(new[] { "ActivityType" }, "IX_ActivityLog_ActivityType");
+
+                    b.HasIndex(new[] { "TicketId" }, "IX_ActivityLog_TicketID");
+
+                    b.HasIndex(new[] { "UserId" }, "IX_ActivityLog_UserID");
 
                     b.ToTable("ActivityLog", (string)null);
                 });
@@ -99,6 +103,12 @@ namespace ASI.Basecode.Data.Migrations
 
                     b.HasKey("AdminId");
 
+                    b.HasIndex(new[] { "Email" }, "IX_Admin_Email");
+
+                    b.HasIndex(new[] { "IsSuper" }, "IX_Admin_IsSuper");
+
+                    b.HasIndex(new[] { "Name" }, "IX_Admin_Name");
+
                     b.ToTable("Admin", (string)null);
                 });
 
@@ -121,6 +131,8 @@ namespace ASI.Basecode.Data.Migrations
                         .HasColumnName("description");
 
                     b.HasKey("CategoryId");
+
+                    b.HasIndex(new[] { "CategoryName" }, "IX_ArticleCategory_Name");
 
                     b.ToTable("ArticleCategory", (string)null);
                 });
@@ -163,7 +175,11 @@ namespace ASI.Basecode.Data.Migrations
 
                     b.HasKey("AttachmentId");
 
-                    b.HasIndex("TicketId");
+                    b.HasIndex(new[] { "Name" }, "IX_Attachment_Name");
+
+                    b.HasIndex(new[] { "TicketId" }, "IX_Attachment_TicketID");
+
+                    b.HasIndex(new[] { "UploadedDate" }, "IX_Attachment_UploadedDate");
 
                     b.ToTable("Attachment", (string)null);
                 });
@@ -188,7 +204,60 @@ namespace ASI.Basecode.Data.Migrations
 
                     b.HasKey("CategoryTypeId");
 
+                    b.HasIndex(new[] { "CategoryName" }, "IX_CategoryType_Name");
+
                     b.ToTable("CategoryType", (string)null);
+                });
+
+            modelBuilder.Entity("ASI.Basecode.Data.Models.Comment", b =>
+                {
+                    b.Property<string>("CommentId")
+                        .HasMaxLength(256)
+                        .HasColumnType("nvarchar(256)")
+                        .HasColumnName("comment_ID");
+
+                    b.Property<string>("Content")
+                        .IsRequired()
+                        .HasMaxLength(500)
+                        .HasColumnType("nvarchar(500)")
+                        .HasColumnName("content");
+
+                    b.Property<string>("ParentId")
+                        .HasMaxLength(256)
+                        .HasColumnType("nvarchar(256)")
+                        .HasColumnName("parent_ID");
+
+                    b.Property<DateTime>("PostedDate")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("datetime")
+                        .HasColumnName("postedDate")
+                        .HasDefaultValueSql("(getdate())");
+
+                    b.Property<string>("TicketId")
+                        .IsRequired()
+                        .HasMaxLength(256)
+                        .HasColumnType("nvarchar(256)")
+                        .HasColumnName("ticket_ID");
+
+                    b.Property<DateTime?>("UpdatedDate")
+                        .HasColumnType("datetime")
+                        .HasColumnName("updatedDate");
+
+                    b.Property<string>("UserId")
+                        .IsRequired()
+                        .HasMaxLength(256)
+                        .HasColumnType("nvarchar(256)")
+                        .HasColumnName("user_ID");
+
+                    b.HasKey("CommentId");
+
+                    b.HasIndex(new[] { "ParentId" }, "IX_Comment_ParentID");
+
+                    b.HasIndex(new[] { "TicketId" }, "IX_Comment_TicketID");
+
+                    b.HasIndex(new[] { "UserId" }, "IX_Comment_UserID");
+
+                    b.ToTable("Comment", (string)null);
                 });
 
             modelBuilder.Entity("ASI.Basecode.Data.Models.Feedback", b =>
@@ -209,6 +278,10 @@ namespace ASI.Basecode.Data.Migrations
                         .HasColumnType("nvarchar(max)")
                         .HasColumnName("feedbackContent");
 
+                    b.Property<int>("FeedbackRating")
+                        .HasColumnType("int")
+                        .HasColumnName("feedbackRating");
+
                     b.Property<string>("TicketId")
                         .IsRequired()
                         .HasMaxLength(256)
@@ -223,9 +296,16 @@ namespace ASI.Basecode.Data.Migrations
 
                     b.HasKey("FeedbackId");
 
-                    b.HasIndex("TicketId");
+                    b.HasIndex(new[] { "CreatedDate" }, "IX_Feedback_CreatedDate");
 
-                    b.HasIndex("UserId");
+                    b.HasIndex(new[] { "FeedbackRating" }, "IX_Feedback_Rating");
+
+                    b.HasIndex(new[] { "TicketId" }, "IX_Feedback_TicketID");
+
+                    b.HasIndex(new[] { "UserId" }, "IX_Feedback_UserID");
+
+                    b.HasIndex(new[] { "TicketId" }, "UQ__Feedback__D597FD62F2D4909F")
+                        .IsUnique();
 
                     b.ToTable("Feedback", (string)null);
                 });
@@ -260,6 +340,10 @@ namespace ASI.Basecode.Data.Migrations
                         .HasColumnName("createdDate")
                         .HasDefaultValueSql("(getdate())");
 
+                    b.Property<bool>("IsDeleted")
+                        .HasColumnType("bit")
+                        .HasColumnName("isDeleted");
+
                     b.Property<string>("Title")
                         .IsRequired()
                         .HasMaxLength(100)
@@ -272,9 +356,17 @@ namespace ASI.Basecode.Data.Migrations
 
                     b.HasKey("ArticleId");
 
-                    b.HasIndex("AuthorId");
+                    b.HasIndex(new[] { "AuthorId" }, "IX_KnowledgeBaseArticle_AuthorID");
 
-                    b.HasIndex("CategoryId");
+                    b.HasIndex(new[] { "CategoryId" }, "IX_KnowledgeBaseArticle_CategoryID");
+
+                    b.HasIndex(new[] { "CreatedDate" }, "IX_KnowledgeBaseArticle_CreatedDate");
+
+                    b.HasIndex(new[] { "IsDeleted" }, "IX_KnowledgeBaseArticle_IsDeleted");
+
+                    b.HasIndex(new[] { "Title" }, "IX_KnowledgeBaseArticle_Title");
+
+                    b.HasIndex(new[] { "UpdatedDate" }, "IX_KnowledgeBaseArticle_UpdatedDate");
 
                     b.ToTable("KnowledgeBaseArticle", (string)null);
                 });
@@ -285,6 +377,15 @@ namespace ASI.Basecode.Data.Migrations
                         .HasMaxLength(256)
                         .HasColumnType("nvarchar(256)")
                         .HasColumnName("notification_ID");
+
+                    b.Property<string>("Description")
+                        .IsRequired()
+                        .HasMaxLength(500)
+                        .HasColumnType("nvarchar(500)")
+                        .HasColumnName("description");
+
+                    b.Property<bool>("IsRead")
+                        .HasColumnType("bit");
 
                     b.Property<DateTime>("NotificationDate")
                         .ValueGeneratedOnAdd()
@@ -304,11 +405,25 @@ namespace ASI.Basecode.Data.Migrations
                         .HasColumnType("nvarchar(256)")
                         .HasColumnName("ticket_ID");
 
+                    b.Property<string>("Title")
+                        .IsRequired()
+                        .HasMaxLength(500)
+                        .HasColumnType("nvarchar(500)")
+                        .HasColumnName("title");
+
+                    b.Property<string>("UserId")
+                        .IsRequired()
+                        .HasMaxLength(256)
+                        .HasColumnType("nvarchar(256)")
+                        .HasColumnName("userId");
+
                     b.HasKey("NotificationId");
 
-                    b.HasIndex("NotificationTypeId");
+                    b.HasIndex(new[] { "NotificationDate" }, "IX_Notification_Date");
 
-                    b.HasIndex("TicketId");
+                    b.HasIndex(new[] { "TicketId" }, "IX_Notification_TicketID");
+
+                    b.HasIndex(new[] { "NotificationTypeId" }, "IX_Notification_TypeID");
 
                     b.ToTable("Notification", (string)null);
                 });
@@ -332,6 +447,8 @@ namespace ASI.Basecode.Data.Migrations
                         .HasColumnName("title");
 
                     b.HasKey("NotificationTypeId");
+
+                    b.HasIndex(new[] { "Title" }, "IX_NotificationType_Title");
 
                     b.ToTable("NotificationType", (string)null);
                 });
@@ -359,6 +476,12 @@ namespace ASI.Basecode.Data.Migrations
 
                     b.HasKey("ReportId");
 
+                    b.HasIndex(new[] { "AssignedDate" }, "IX_PerformanceReport_AssignedDate");
+
+                    b.HasIndex(new[] { "AverageResolutionTime" }, "IX_PerformanceReport_AvgResolutionTime");
+
+                    b.HasIndex(new[] { "ResolvedTickets" }, "IX_PerformanceReport_ResolvedTickets");
+
                     b.ToTable("PerformanceReport", (string)null);
                 });
 
@@ -381,6 +504,8 @@ namespace ASI.Basecode.Data.Migrations
                         .HasColumnName("priorityName");
 
                     b.HasKey("PriorityTypeId");
+
+                    b.HasIndex(new[] { "PriorityName" }, "IX_PriorityType_Name");
 
                     b.ToTable("PriorityType", (string)null);
                 });
@@ -405,6 +530,8 @@ namespace ASI.Basecode.Data.Migrations
 
                     b.HasKey("RoleId");
 
+                    b.HasIndex(new[] { "RoleName" }, "IX_Role_Name");
+
                     b.ToTable("Role", (string)null);
                 });
 
@@ -428,6 +555,8 @@ namespace ASI.Basecode.Data.Migrations
 
                     b.HasKey("StatusTypeId");
 
+                    b.HasIndex(new[] { "StatusName" }, "IX_StatusType_Name");
+
                     b.ToTable("StatusType", (string)null);
                 });
 
@@ -443,13 +572,29 @@ namespace ASI.Basecode.Data.Migrations
                         .HasColumnType("nvarchar(500)")
                         .HasColumnName("description");
 
+                    b.Property<bool>("IsDeleted")
+                        .HasColumnType("bit")
+                        .HasColumnName("isDeleted");
+
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(100)
                         .HasColumnType("nvarchar(100)")
                         .HasColumnName("name");
 
+                    b.Property<string>("SpecializationId")
+                        .IsRequired()
+                        .HasMaxLength(256)
+                        .HasColumnType("nvarchar(256)")
+                        .HasColumnName("specialization_ID");
+
                     b.HasKey("TeamId");
+
+                    b.HasIndex(new[] { "IsDeleted" }, "IX_Team_IsDeleted");
+
+                    b.HasIndex(new[] { "Name" }, "IX_Team_Name");
+
+                    b.HasIndex(new[] { "SpecializationId" }, "IX_Team_SpecializationID");
 
                     b.ToTable("Team", (string)null);
                 });
@@ -473,9 +618,12 @@ namespace ASI.Basecode.Data.Migrations
 
                     b.HasKey("TeamId", "UserId");
 
-                    b.HasIndex("ReportId");
+                    b.HasIndex(new[] { "ReportId" }, "IX_TeamMember_ReportID");
 
-                    b.HasIndex("UserId");
+                    b.HasIndex(new[] { "UserId" }, "IX_TeamMember_UserID");
+
+                    b.HasIndex(new[] { "UserId" }, "UQ__TeamMemb__B9BF330619573A22")
+                        .IsUnique();
 
                     b.ToTable("TeamMember", (string)null);
                 });
@@ -498,6 +646,10 @@ namespace ASI.Basecode.Data.Migrations
                         .HasColumnType("datetime")
                         .HasColumnName("createdDate")
                         .HasDefaultValueSql("(getdate())");
+
+                    b.Property<bool>("IsDeleted")
+                        .HasColumnType("bit")
+                        .HasColumnName("isDeleted");
 
                     b.Property<string>("IssueDescription")
                         .IsRequired()
@@ -539,13 +691,23 @@ namespace ASI.Basecode.Data.Migrations
 
                     b.HasKey("TicketId");
 
-                    b.HasIndex("CategoryTypeId");
+                    b.HasIndex(new[] { "CategoryTypeId" }, "IX_Ticket_CategoryTypeID");
 
-                    b.HasIndex("PriorityTypeId");
+                    b.HasIndex(new[] { "CreatedDate" }, "IX_Ticket_CreatedDate");
 
-                    b.HasIndex("StatusTypeId");
+                    b.HasIndex(new[] { "IsDeleted" }, "IX_Ticket_IsDeleted");
 
-                    b.HasIndex("UserId");
+                    b.HasIndex(new[] { "PriorityTypeId" }, "IX_Ticket_PriorityTypeID");
+
+                    b.HasIndex(new[] { "ResolvedDate" }, "IX_Ticket_ResolvedDate");
+
+                    b.HasIndex(new[] { "StatusTypeId" }, "IX_Ticket_StatusTypeID");
+
+                    b.HasIndex(new[] { "Subject" }, "IX_Ticket_Subject");
+
+                    b.HasIndex(new[] { "UpdatedDate" }, "IX_Ticket_UpdatedDate");
+
+                    b.HasIndex(new[] { "UserId" }, "IX_Ticket_UserID");
 
                     b.ToTable("Ticket", (string)null);
                 });
@@ -557,11 +719,17 @@ namespace ASI.Basecode.Data.Migrations
                         .HasColumnType("nvarchar(256)")
                         .HasColumnName("assignment_ID");
 
-                    b.Property<string>("AdminId")
+                    b.Property<string>("AgentId")
                         .IsRequired()
                         .HasMaxLength(256)
                         .HasColumnType("nvarchar(256)")
-                        .HasColumnName("admin_ID");
+                        .HasColumnName("agent_ID");
+
+                    b.Property<string>("AssignedById")
+                        .IsRequired()
+                        .HasMaxLength(256)
+                        .HasColumnType("nvarchar(256)")
+                        .HasColumnName("assignedBy_ID");
 
                     b.Property<DateTime>("AssignedDate")
                         .ValueGeneratedOnAdd()
@@ -570,7 +738,6 @@ namespace ASI.Basecode.Data.Migrations
                         .HasDefaultValueSql("(getdate())");
 
                     b.Property<string>("TeamId")
-                        .IsRequired()
                         .HasMaxLength(256)
                         .HasColumnType("nvarchar(256)")
                         .HasColumnName("team_ID");
@@ -583,11 +750,18 @@ namespace ASI.Basecode.Data.Migrations
 
                     b.HasKey("AssignmentId");
 
-                    b.HasIndex("AdminId");
+                    b.HasIndex(new[] { "AgentId" }, "IX_TicketAssignment_AgentID");
 
-                    b.HasIndex("TeamId");
+                    b.HasIndex(new[] { "AssignedById" }, "IX_TicketAssignment_AssignedByID");
 
-                    b.HasIndex("TicketId");
+                    b.HasIndex(new[] { "AssignedDate" }, "IX_TicketAssignment_AssignedDate");
+
+                    b.HasIndex(new[] { "TeamId" }, "IX_TicketAssignment_TeamID");
+
+                    b.HasIndex(new[] { "TicketId" }, "IX_TicketAssignment_TicketID");
+
+                    b.HasIndex(new[] { "TicketId" }, "UQ__TicketAs__D597FD62C7FD3914")
+                        .IsUnique();
 
                     b.ToTable("TicketAssignment", (string)null);
                 });
@@ -646,11 +820,19 @@ namespace ASI.Basecode.Data.Migrations
 
                     b.HasKey("UserId");
 
-                    b.HasIndex("CreatedBy");
+                    b.HasIndex(new[] { "CreatedBy" }, "IX_User_CreatedBy");
 
-                    b.HasIndex("RoleId");
+                    b.HasIndex(new[] { "CreatedTime" }, "IX_User_CreatedTime");
 
-                    b.HasIndex("UpdatedBy");
+                    b.HasIndex(new[] { "Email" }, "IX_User_Email");
+
+                    b.HasIndex(new[] { "Name" }, "IX_User_Name");
+
+                    b.HasIndex(new[] { "RoleId" }, "IX_User_RoleID");
+
+                    b.HasIndex(new[] { "UpdatedBy" }, "IX_User_UpdatedBy");
+
+                    b.HasIndex(new[] { "UpdatedTime" }, "IX_User_UpdatedTime");
 
                     b.ToTable("User", (string)null);
                 });
@@ -685,11 +867,37 @@ namespace ASI.Basecode.Data.Migrations
                     b.Navigation("Ticket");
                 });
 
+            modelBuilder.Entity("ASI.Basecode.Data.Models.Comment", b =>
+                {
+                    b.HasOne("ASI.Basecode.Data.Models.Comment", "Parent")
+                        .WithMany("InverseParent")
+                        .HasForeignKey("ParentId")
+                        .HasConstraintName("FK_Comment_Parent");
+
+                    b.HasOne("ASI.Basecode.Data.Models.Ticket", "Ticket")
+                        .WithMany("Comments")
+                        .HasForeignKey("TicketId")
+                        .IsRequired()
+                        .HasConstraintName("FK_Comment_Ticket");
+
+                    b.HasOne("ASI.Basecode.Data.Models.User", "User")
+                        .WithMany("Comments")
+                        .HasForeignKey("UserId")
+                        .IsRequired()
+                        .HasConstraintName("FK_Comment_User");
+
+                    b.Navigation("Parent");
+
+                    b.Navigation("Ticket");
+
+                    b.Navigation("User");
+                });
+
             modelBuilder.Entity("ASI.Basecode.Data.Models.Feedback", b =>
                 {
                     b.HasOne("ASI.Basecode.Data.Models.Ticket", "Ticket")
-                        .WithMany("Feedbacks")
-                        .HasForeignKey("TicketId")
+                        .WithOne("Feedback")
+                        .HasForeignKey("ASI.Basecode.Data.Models.Feedback", "TicketId")
                         .IsRequired()
                         .HasConstraintName("FK_Feedback_Ticket");
 
@@ -742,6 +950,17 @@ namespace ASI.Basecode.Data.Migrations
                     b.Navigation("Ticket");
                 });
 
+            modelBuilder.Entity("ASI.Basecode.Data.Models.Team", b =>
+                {
+                    b.HasOne("ASI.Basecode.Data.Models.CategoryType", "Specialization")
+                        .WithMany("Teams")
+                        .HasForeignKey("SpecializationId")
+                        .IsRequired()
+                        .HasConstraintName("FK_Team_Specialization");
+
+                    b.Navigation("Specialization");
+                });
+
             modelBuilder.Entity("ASI.Basecode.Data.Models.TeamMember", b =>
                 {
                     b.HasOne("ASI.Basecode.Data.Models.PerformanceReport", "Report")
@@ -756,8 +975,8 @@ namespace ASI.Basecode.Data.Migrations
                         .HasConstraintName("FK_TeamMember_Team");
 
                     b.HasOne("ASI.Basecode.Data.Models.User", "User")
-                        .WithMany("TeamMembers")
-                        .HasForeignKey("UserId")
+                        .WithOne("TeamMember")
+                        .HasForeignKey("ASI.Basecode.Data.Models.TeamMember", "UserId")
                         .IsRequired()
                         .HasConstraintName("FK_TeamMember_User");
 
@@ -805,25 +1024,32 @@ namespace ASI.Basecode.Data.Migrations
 
             modelBuilder.Entity("ASI.Basecode.Data.Models.TicketAssignment", b =>
                 {
-                    b.HasOne("ASI.Basecode.Data.Models.Admin", "Admin")
-                        .WithMany("TicketAssignments")
-                        .HasForeignKey("AdminId")
+                    b.HasOne("ASI.Basecode.Data.Models.User", "Agent")
+                        .WithMany("TicketAssignmentAgents")
+                        .HasForeignKey("AgentId")
                         .IsRequired()
-                        .HasConstraintName("FK_TicketAssignment_Admin");
+                        .HasConstraintName("FK_TicketAssignment_Agent");
+
+                    b.HasOne("ASI.Basecode.Data.Models.User", "AssignedBy")
+                        .WithMany("TicketAssignmentAssignedBies")
+                        .HasForeignKey("AssignedById")
+                        .IsRequired()
+                        .HasConstraintName("FK_TicketAssignment_AssignedBy");
 
                     b.HasOne("ASI.Basecode.Data.Models.Team", "Team")
                         .WithMany("TicketAssignments")
                         .HasForeignKey("TeamId")
-                        .IsRequired()
                         .HasConstraintName("FK_TicketAssignment_Team");
 
                     b.HasOne("ASI.Basecode.Data.Models.Ticket", "Ticket")
-                        .WithMany("TicketAssignments")
-                        .HasForeignKey("TicketId")
+                        .WithOne("TicketAssignment")
+                        .HasForeignKey("ASI.Basecode.Data.Models.TicketAssignment", "TicketId")
                         .IsRequired()
                         .HasConstraintName("FK_TicketAssignment_Ticket");
 
-                    b.Navigation("Admin");
+                    b.Navigation("Agent");
+
+                    b.Navigation("AssignedBy");
 
                     b.Navigation("Team");
 
@@ -858,8 +1084,6 @@ namespace ASI.Basecode.Data.Migrations
 
             modelBuilder.Entity("ASI.Basecode.Data.Models.Admin", b =>
                 {
-                    b.Navigation("TicketAssignments");
-
                     b.Navigation("UserCreatedByNavigations");
 
                     b.Navigation("UserUpdatedByNavigations");
@@ -872,7 +1096,14 @@ namespace ASI.Basecode.Data.Migrations
 
             modelBuilder.Entity("ASI.Basecode.Data.Models.CategoryType", b =>
                 {
+                    b.Navigation("Teams");
+
                     b.Navigation("Tickets");
+                });
+
+            modelBuilder.Entity("ASI.Basecode.Data.Models.Comment", b =>
+                {
+                    b.Navigation("InverseParent");
                 });
 
             modelBuilder.Entity("ASI.Basecode.Data.Models.NotificationType", b =>
@@ -913,22 +1144,30 @@ namespace ASI.Basecode.Data.Migrations
 
                     b.Navigation("Attachments");
 
-                    b.Navigation("Feedbacks");
+                    b.Navigation("Comments");
+
+                    b.Navigation("Feedback");
 
                     b.Navigation("Notifications");
 
-                    b.Navigation("TicketAssignments");
+                    b.Navigation("TicketAssignment");
                 });
 
             modelBuilder.Entity("ASI.Basecode.Data.Models.User", b =>
                 {
                     b.Navigation("ActivityLogs");
 
+                    b.Navigation("Comments");
+
                     b.Navigation("Feedbacks");
 
                     b.Navigation("KnowledgeBaseArticles");
 
-                    b.Navigation("TeamMembers");
+                    b.Navigation("TeamMember");
+
+                    b.Navigation("TicketAssignmentAgents");
+
+                    b.Navigation("TicketAssignmentAssignedBies");
 
                     b.Navigation("Tickets");
                 });

--- a/ASI.Basecode.Data/Migrations/AddDefaultValues.cs
+++ b/ASI.Basecode.Data/Migrations/AddDefaultValues.cs
@@ -12,7 +12,8 @@ namespace ASI.Basecode.Data.Migrations
             migrationBuilder.InsertData(
                 table: "Admin",
                 columns: new[] { "admin_ID", "name", "email", "password", "isSuper" },
-                values: new object[,] { 
+                values: new object[,] 
+                {
                     { "D56F556E-50A4-4240-A0FF-9A6898B3A03B", "Joel", "joel@example.com", "securepassword", true },
                     { "cb2d0c01-ef51-4deb-96dd-f57c25497fe3", "Jane Doe", "123@", "Kw7+jFXwfGw/o6Mi2vJEXw==", true },
                 }
@@ -26,15 +27,15 @@ namespace ASI.Basecode.Data.Migrations
                     { "Admin", "Admin", "Administrator with full access to the system" },
                     { "Support Agent", "Support Agent", "Support agent with access to help desk functionalities" },
                     { "Employee", "Employee", "Employee with basic access to the system" }
-                } 
+                }
             );
 
             migrationBuilder.InsertData(
                 table: "User",
                 columns: new[] { "user_ID", "name", "email", "password", "role_ID", "createdBy", "createdTime", "updatedTime", "updatedBy" },
-                values: new object[,] 
+                values: new object[,]
                 {
-                    { "cb2d0c01-ef51-4deb-96dd-f57c25497fe3", "Jane Doe", "123@", "Kw7+jFXwfGw/o6Mi2vJEXw==", "Admin", 
+                    { "cb2d0c01-ef51-4deb-96dd-f57c25497fe3", "Jane Doe", "123@", "Kw7+jFXwfGw/o6Mi2vJEXw==", "Admin",
                         "D56F556E-50A4-4240-A0FF-9A6898B3A03B", DateTime.Now, DateTime.Now, "D56F556E-50A4-4240-A0FF-9A6898B3A03B" },
                     { "5c8185f8-a1ce-4175-8179-f9a055c8d3c4", "Agent A", "agenta@ticketita.com", "WDCHwzavyvUzFb/JBYNiCg==", "Support Agent",
                         "D56F556E-50A4-4240-A0FF-9A6898B3A03B", DateTime.Now, DateTime.Now, "D56F556E-50A4-4240-A0FF-9A6898B3A03B" },
@@ -50,8 +51,8 @@ namespace ASI.Basecode.Data.Migrations
             migrationBuilder.InsertData(
                 table: "PriorityType",
                 columns: new[] { "priorityType_ID", "priorityName", "description" },
-                values: new object[,] 
-                { 
+                values: new object[,]
+                {
                     { "P1", "Critical", "Ticket with the highest priority." },
                     { "P2", "High", "Ticket with high priority." },
                     { "P3", "Medium", "Ticket with medium priority." },
@@ -86,21 +87,13 @@ namespace ASI.Basecode.Data.Migrations
 
             migrationBuilder.InsertData(
                 table: "Team",
-                columns: new[] { "team_ID", "name", "description" },
+                columns: new[] { "team_ID", "name", "description", "specialization_ID" },
                 values: new object[,]
                 {
-                    { "33e3e490-cf80-428b-b1d6-67c3455ac462", "A-Team", "Amazing team." },
-                    { "0ee1f465-9b7d-4199-b384-121990d92f9d", "B-Team", "Bmazing team." }
-                }
-            );
-
-            migrationBuilder.InsertData(
-                table: "TeamMember",
-                columns: new[] { "team_ID", "user_ID", "report_ID" },
-                values: new object[,]
-                {
-                    { "33e3e490-cf80-428b-b1d6-67c3455ac462", "5c8185f8-a1ce-4175-8179-f9a055c8d3c4", null },
-                    { "0ee1f465-9b7d-4199-b384-121990d92f9d", "71e6123f-641d-42fe-937f-07a5cd27977f", null }
+                    { $"{Guid.NewGuid().ToString()}", "Software Saviors", "The team specializes in software related issues.", "C1" },
+                    { $"{Guid.NewGuid().ToString()}", "Hardware Heroes", "The team specializes in hardware related issues.", "C2" },
+                    { $"{Guid.NewGuid().ToString()}", "Network Ninjas", "The team specializes in network related issues.", "C3" },
+                    { $"{Guid.NewGuid().ToString()}", "Access Aces", "The team specializes in account related issues.", "C4" },
                 }
             );
 

--- a/ASI.Basecode.Data/Models/Admin.cs
+++ b/ASI.Basecode.Data/Models/Admin.cs
@@ -7,7 +7,6 @@ namespace ASI.Basecode.Data.Models
     {
         public Admin()
         {
-            TicketAssignments = new HashSet<TicketAssignment>();
             UserCreatedByNavigations = new HashSet<User>();
             UserUpdatedByNavigations = new HashSet<User>();
         }
@@ -18,7 +17,6 @@ namespace ASI.Basecode.Data.Models
         public string Password { get; set; }
         public bool IsSuper { get; set; }
 
-        public virtual ICollection<TicketAssignment> TicketAssignments { get; set; }
         public virtual ICollection<User> UserCreatedByNavigations { get; set; }
         public virtual ICollection<User> UserUpdatedByNavigations { get; set; }
     }

--- a/ASI.Basecode.Data/Models/CategoryType.cs
+++ b/ASI.Basecode.Data/Models/CategoryType.cs
@@ -7,6 +7,7 @@ namespace ASI.Basecode.Data.Models
     {
         public CategoryType()
         {
+            Teams = new HashSet<Team>();
             Tickets = new HashSet<Ticket>();
         }
 
@@ -14,6 +15,7 @@ namespace ASI.Basecode.Data.Models
         public string CategoryName { get; set; }
         public string Description { get; set; }
 
+        public virtual ICollection<Team> Teams { get; set; }
         public virtual ICollection<Ticket> Tickets { get; set; }
     }
 }

--- a/ASI.Basecode.Data/Models/Team.cs
+++ b/ASI.Basecode.Data/Models/Team.cs
@@ -14,8 +14,10 @@ namespace ASI.Basecode.Data.Models
         public string TeamId { get; set; }
         public string Name { get; set; }
         public string Description { get; set; }
+        public string SpecializationId { get; set; }
         public bool IsDeleted { get; set; }
 
+        public virtual CategoryType Specialization { get; set; }
         public virtual ICollection<TeamMember> TeamMembers { get; set; }
         public virtual ICollection<TicketAssignment> TicketAssignments { get; set; }
     }

--- a/ASI.Basecode.Data/Models/TicketAssignment.cs
+++ b/ASI.Basecode.Data/Models/TicketAssignment.cs
@@ -7,11 +7,13 @@ namespace ASI.Basecode.Data.Models
     {
         public string AssignmentId { get; set; }
         public string TeamId { get; set; }
+        public string AgentId { get; set; }
         public string TicketId { get; set; }
         public DateTime AssignedDate { get; set; }
-        public string AdminId { get; set; }
+        public string AssignedById { get; set; }
 
-        public virtual Admin Admin { get; set; }
+        public virtual User Agent { get; set; }
+        public virtual User AssignedBy { get; set; }
         public virtual Team Team { get; set; }
         public virtual Ticket Ticket { get; set; }
     }

--- a/ASI.Basecode.Data/Models/User.cs
+++ b/ASI.Basecode.Data/Models/User.cs
@@ -11,6 +11,8 @@ namespace ASI.Basecode.Data.Models
             Comments = new HashSet<Comment>();
             Feedbacks = new HashSet<Feedback>();
             KnowledgeBaseArticles = new HashSet<KnowledgeBaseArticle>();
+            TicketAssignmentAgents = new HashSet<TicketAssignment>();
+            TicketAssignmentAssignedBies = new HashSet<TicketAssignment>();
             Tickets = new HashSet<Ticket>();
         }
 
@@ -23,6 +25,7 @@ namespace ASI.Basecode.Data.Models
         public DateTime CreatedTime { get; set; }
         public string UpdatedBy { get; set; }
         public DateTime? UpdatedTime { get; set; }
+
         public virtual Admin CreatedByNavigation { get; set; }
         public virtual Role Role { get; set; }
         public virtual Admin UpdatedByNavigation { get; set; }
@@ -31,6 +34,8 @@ namespace ASI.Basecode.Data.Models
         public virtual ICollection<Comment> Comments { get; set; }
         public virtual ICollection<Feedback> Feedbacks { get; set; }
         public virtual ICollection<KnowledgeBaseArticle> KnowledgeBaseArticles { get; set; }
+        public virtual ICollection<TicketAssignment> TicketAssignmentAgents { get; set; }
+        public virtual ICollection<TicketAssignment> TicketAssignmentAssignedBies { get; set; }
         public virtual ICollection<Ticket> Tickets { get; set; }
     }
 }

--- a/ASI.Basecode.Data/Repositories/TeamRepository.cs
+++ b/ASI.Basecode.Data/Repositories/TeamRepository.cs
@@ -21,13 +21,14 @@ namespace ASI.Basecode.Data.Repositories
         private IQueryable<Team> GetTeamsWithIncludes()
         {
             return this.GetDbSet<Team>()
-                        .Where(team => !team.IsDeleted)
-                        .Include(f => f.TeamMembers)
+                        .Where(t => !t.IsDeleted)
+                        .Include(t => t.TeamMembers)
                             .ThenInclude(u => u.User)
-                        .Include(f => f.TeamMembers)
+                        .Include(t => t.TeamMembers)
                             .ThenInclude(u => u.Report)
-                        .Include(f => f.TicketAssignments)
-                            .ThenInclude(a => a.Admin);
+                        .Include(t => t.TicketAssignments)
+                            .ThenInclude(a => a.Agent)
+                        .Include(t => t.Specialization);
         }
 
         public async Task<List<Team>> GetAllAsync() =>
@@ -66,13 +67,40 @@ namespace ASI.Basecode.Data.Repositories
 
         public async Task<IEnumerable<Team>> GetAllStrippedAsync()
         {
-            return await this.GetDbSet<Team>()
+            return this.GetDbSet<Team>()
                         .Where(team => !team.IsDeleted)
-                        .Select(team => new Team
+                        .Select(team => new
                         {
-                            TeamId = team.TeamId,
-                            Name = team.Name
-                        }).ToListAsync();
+                            team.TeamId,
+                            team.Name,
+                            TeamSpecialization = new CategoryType
+                            {
+                                CategoryTypeId = team.Specialization.CategoryTypeId,
+                                CategoryName = team.Specialization.CategoryName
+                            },
+                            TeamMembers = team.TeamMembers
+                                .Select(member => new
+                                {
+                                    member.UserId,
+                                    member.User.Name
+                                })
+                        })
+                        .AsEnumerable()
+                        .Select(t => new Team
+                        {
+                            TeamId = t.TeamId,
+                            Name = t.Name,
+                            TeamMembers = t.TeamMembers.Select(m => new TeamMember
+                            {
+                                UserId = m.UserId,
+                                User = new User
+                                {
+                                    Name = m.Name
+                                }
+                            })
+                            .ToList(),
+                            Specialization = t.TeamSpecialization
+                        });
         }
 
         public async Task<IEnumerable<User>> GetAgentsAsync()
@@ -101,8 +129,10 @@ namespace ASI.Basecode.Data.Repositories
                         .Include(u => u.Role)
                         .Include(u => u.UpdatedByNavigation)
                         .Include(u => u.TeamMember)
+                            .ThenInclude(tm => tm.Team)
                         .Include(u => u.ActivityLogs)
                         .Include(u => u.KnowledgeBaseArticles)
+                        .Include(u => u.TicketAssignmentAgents)
                         .FirstOrDefaultAsync(u => u.UserId == id);
         }
 

--- a/ASI.Basecode.Data/Repositories/TicketRepository.cs
+++ b/ASI.Basecode.Data/Repositories/TicketRepository.cs
@@ -40,9 +40,9 @@ namespace ASI.Basecode.Data.Repositories
                     .Include(t => t.Comments)
                         .ThenInclude(c => c.InverseParent)
                     .Include(t => t.TicketAssignment)
-                        .ThenInclude(ta => ta.Team)
-                        .ThenInclude(team => team.TeamMembers)
-                        .ThenInclude(tm => tm.User);
+                        .ThenInclude(ta => ta.Agent)
+                    .Include(t => t.TicketAssignment)
+                        .ThenInclude(ta => ta.Team);
         }
 
         /// <summary>
@@ -140,6 +140,16 @@ namespace ASI.Basecode.Data.Repositories
         public async Task AssignTicketAsync(TicketAssignment assignment)
         {
             await this.GetDbSet<TicketAssignment>().AddAsync(assignment);
+            await UnitOfWork.SaveChangesAsync();
+        }
+
+        /// <summary>
+        /// Updates a ticket assignment.
+        /// </summary>
+        /// <param name="assignment">The assignment.</param>
+        public async Task UpdateAssignmentAsync(TicketAssignment assignment)
+        {
+            this.GetDbSet<TicketAssignment>().Update(assignment);
             await UnitOfWork.SaveChangesAsync();
         }
 

--- a/ASI.Basecode.Services/ServiceModels/TeamViewModel.cs
+++ b/ASI.Basecode.Services/ServiceModels/TeamViewModel.cs
@@ -21,13 +21,15 @@ namespace ASI.Basecode.Services.ServiceModels
 
         [Display(Name = "Description")]
         public string Description { get; set; }
-        #endregion
 
+        [Display(Name = "Specialization")]
+        public string SpecializationId { get; set; }
+        #endregion
 
         #region Team Navigation Properties
         [Display(Name = "Number of Agents")]
         public IEnumerable<TeamMember> TeamMembers { get; set; }
-
+        public CategoryType Specialization { get; set; }
         public IEnumerable<TicketAssignment> TicketAssignments { get; set; }
         #endregion
 

--- a/ASI.Basecode.Services/ServiceModels/TicketViewModel.cs
+++ b/ASI.Basecode.Services/ServiceModels/TicketViewModel.cs
@@ -64,10 +64,15 @@ namespace ASI.Basecode.Services.ServiceModels
 
         #region Relationships
         public string AgentId { get; set; }
+        public string TeamId { get; set; }
 
         /// <summary>The agent assigned to the ticket.</summary>
-        [Display(Name = "Assignee")]
+        [Display(Name = "Agent")]
         public User Agent { get; set; }
+
+        /// <summary>The team assigned to the ticket.</summary>
+        [Display(Name = "Team")]
+        public Team Team { get; set; }
 
         /// <summary>Holds the ticket assignment values.</summary>
         [Display(Name = "Ticket Assignee")]
@@ -105,8 +110,12 @@ namespace ASI.Basecode.Services.ServiceModels
 
 
         #region Dropdown Population
+        [Display(Name = "Teams")]
+        public IEnumerable<Team> Teams { get; set; }
         [Display(Name = "Support Agents")]
         public IEnumerable<User> Agents { get; set; }
+        public IEnumerable<User> AgentsWithNoTeam { get; set; }
+
         [Display(Name = "Users")]
         public IEnumerable<User> Users { get; set; }
 

--- a/ASI.Basecode.Services/Services/TicketService.Assignment.cs
+++ b/ASI.Basecode.Services/Services/TicketService.Assignment.cs
@@ -6,6 +6,8 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using static ASI.Basecode.Services.Exceptions.TicketExceptions;
 using static ASI.Basecode.Services.Exceptions.TeamExceptions;
+using System.Security.Claims;
+using Microsoft.Extensions.Logging;
 
 namespace ASI.Basecode.Services.Services
 {
@@ -16,55 +18,117 @@ namespace ASI.Basecode.Services.Services
         /// </summary>
         /// <param name="model">The model.</param>
         /// <returns>string assignment type: "assign", "unassign", "reassign"</returns>
+        /// new assignment
+        /// case 0: no team, no agent - exception
+        /// case 1: no team, new agent
+        /// case 2: new team, no agent
+        /// case 3: new team, new agent
+        /// ------------------------------
+        /// existing assignment
+        /// case 0: same team, same agent - exception
+        /// case 1: no team, no agent
+        /// case 2: same team, no agent
+        /// case 3: no team, different agent
+        /// case 4: same team, different agent
+        /// case 5: different team, no agent
+        /// case 6: different team, different agent
+        /// case 7: new team from no team, same agent -> no team agent with ticket was assigned to a team
         public async Task<string> UpdateAssignmentAsync(TicketViewModel model)
         {
+            var currentUser = _httpContextAccessor.HttpContext.User?.FindFirst(ClaimTypes.NameIdentifier)?.Value;
             var status = string.Empty;
-            var assignment = await _repository.FindAssignmentByTicketIdAsync(model.TicketId);
-            if (assignment != null)
+            var ticketId = model.TicketId;
+            var teamId = model.TeamId;
+            var agentId = model.AgentId;
+            var assignment = await _repository.FindAssignmentByTicketIdAsync(ticketId);
+            string noTeam = "no_team";
+            string noAgent = "no_agent";
+
+            if (assignment == null)
             {
-                if (model.AgentId == "remove")
+                status = "assign";
+                if (teamId == noTeam && agentId == noAgent)
                 {
-                    status = "unassign";
-                    await CheckAndModifyStatusByAssignment(model.TicketId, status);
-                    await _repository.RemoveAssignmentAsync(assignment);
+                    throw new TicketException("Please select either an agent or a team to continue.", ticketId);
+                }
+
+                if (teamId == noTeam && agentId != noAgent)
+                {
+                    assignment = await CreateTicketAssignmentAsync(ticketId, agentId);
+                }
+                else if (teamId != noTeam && agentId == noAgent)
+                {
+                    assignment = await CreateTicketAssignmentAsync(ticketId, teamId: teamId);
+                }
+                else if (teamId != noTeam && agentId != noAgent)
+                {
+                    assignment = await CreateTicketAssignmentAsync(ticketId, agentId, teamId);
                 }
                 else
                 {
-                    if (model.AgentId == ExtractAgentId(assignment.AssignmentId))
-                        throw new TicketException("Cannot reassign to the same agent.", model.TicketId);
-
-                    status = "reassign";
-                    await CheckAndModifyStatusByAssignment(model.TicketId, status);
-
-                    var ticket = await _repository.FindByIdAsync(model.TicketId);
-                    await _repository.RemoveAssignmentAsync(assignment);
-
-                    assignment = await CreateTicketAssignmentAsync(model.TicketId, model.AgentId);
-                    ticket.TicketAssignment = assignment;
-                    ticket.UpdatedDate = DateTime.Now;
-                    assignment.Ticket = ticket;
-                    await _repository.AssignTicketAsync(assignment);
-
-                    CreateNotification(ticket, null, true, model.AgentId);
+                    throw new TicketException("Invalid assignment update. Please try again.", ticketId);
                 }
+                await _repository.AssignTicketAsync(assignment);
             }
             else
             {
-                if (model.AgentId == "remove")
-                    throw new TicketException("Please select an agent to continue.", model.TicketId);
+                var assignmentTeamId = assignment.TeamId;
+                var assignmentAgentId = assignment.AgentId;
+                if (teamId == assignmentTeamId && agentId == assignmentAgentId)
+                {
+                    throw new TicketException("Cannot reassign to the same team and agent.", ticketId);
+                }
 
-                status = "assign";
-                await CheckAndModifyStatusByAssignment(model.TicketId, status);
-
-                var ticket = await _repository.FindByIdAsync(model.TicketId);
-                assignment = await CreateTicketAssignmentAsync(model.TicketId, model.AgentId);
-                ticket.TicketAssignment = assignment;
-                ticket.UpdatedDate = DateTime.Now;
-                assignment.Ticket = ticket;
-                await _repository.AssignTicketAsync(assignment);
-
-                CreateNotification(ticket, null, false, model.AgentId);
+                if (teamId == noTeam && agentId == noAgent)
+                {
+                    status = "unassign";
+                    await _repository.RemoveAssignmentAsync(assignment);
+                    return status;
+                }
+                
+                if (teamId == assignmentTeamId && agentId == noAgent)
+                {
+                    status = "unassign";
+                    assignment.AgentId = null;
+                }
+                else if (teamId == noTeam && agentId != assignmentAgentId)
+                {
+                    status = "reassign";
+                    assignment.TeamId = null;
+                    assignment.AgentId = agentId;
+                }
+                else if (teamId == assignmentTeamId && agentId != assignmentAgentId)
+                {
+                    status = "reassign";
+                    assignment.AgentId = agentId;
+                }
+                else if (teamId != assignmentTeamId && agentId == noAgent)
+                {
+                    status = "reassign";
+                    assignment.TeamId = teamId;
+                    assignment.AgentId = null;
+                }
+                else if (teamId != assignmentTeamId && agentId != assignmentAgentId)
+                {
+                    status = "reassign";
+                    assignment.TeamId = teamId;
+                    assignment.AgentId = agentId;
+                }
+                else if(string.IsNullOrEmpty(assignmentTeamId) && 
+                    !string.IsNullOrEmpty(teamId) && agentId == assignmentAgentId)
+                {
+                    status = "assign";
+                    assignment.TeamId = teamId;
+                }
+                else
+                {
+                    throw new TicketException("Invalid assignment update. Please try again.", ticketId);
+                }
+                assignment.AssignedDate = DateTime.Now;
+                assignment.AssignedById = currentUser;
+                await _repository.UpdateAssignmentAsync(assignment);
             }
+            await CheckAndModifyStatusByAssignment(ticketId, status);
             return status;
         }
 
@@ -114,24 +178,20 @@ namespace ASI.Basecode.Services.Services
         /// </summary>
         /// <param name="model">The model</param>
         /// <returns>TicketAssignment</returns>
-        /// AssignmentId format: {AgentId}-{Timestamp}-{RandomNumber}
-        private async Task<TicketAssignment> CreateTicketAssignmentAsync(string ticketId, string agentId)
+        private async Task<TicketAssignment> CreateTicketAssignmentAsync(string ticketId, string agentId = null, string teamId = null)
         {
-            var timestamp = DateTime.Now.ToString("yyyyMMddHHmmssfff");
-            var randomNumber = new Random().Next(1000, 9999);
-            var assignmentId = $"{agentId}-{timestamp}-{randomNumber}";
-            var currentAdmin = await GetCurrentAdminAsync();
-            var team = await GetTeamByUserIdAsync(agentId);
+            var currentUser = _httpContextAccessor.HttpContext.User?.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            if (currentUser == null)
+                throw new TicketException("Current user not found, unable to proceed.");
 
             return new TicketAssignment
             {
-                AssignmentId = assignmentId,
-                TeamId = team.TeamId,
+                AssignmentId = Guid.NewGuid().ToString(),
+                AgentId = agentId,
+                TeamId = teamId,
                 TicketId = ticketId,
                 AssignedDate = DateTime.Now,
-                AdminId = currentAdmin.AdminId, //TODO: remove, agent can now reassign
-                Team = team,
-                Admin = currentAdmin
+                AssignedById = currentUser,
             };
         }
     }

--- a/ASI.Basecode.Services/Services/TicketService.GetMethods.cs
+++ b/ASI.Basecode.Services/Services/TicketService.GetMethods.cs
@@ -72,19 +72,15 @@ namespace ASI.Basecode.Services.Services
 
                 foreach (var ticket in tickets)
                 {
-                    /// Agent is assigned to ticket //TODO: SWITCH THIS, CANT ENTER TO CHECK IF ASSIGNED TO TEAM
-                    if (ticket.TicketAssignment?.AgentId == userId)
+                    /// Agent is assigned to a team
+                    if (ticket.TicketAssignment?.TeamId == agentTeamId)
                     {
-                        /// Agent is assigned to a team
-                        if (ticket.TicketAssignment.TeamId == agentTeamId)
-                        {
-                            assignedToAgentTeam.Add(ticket);
-                        }
-                        /// Agent is not assigned to a team
-                        else if (ticket.TicketAssignment.TeamId == null)
-                        {
-                            assignedToAgentNoTeam.Add(ticket);
-                        }
+                        assignedToAgentTeam.Add(ticket);
+                    }
+                    /// Agent is not assigned to a team
+                    else if (ticket.TicketAssignment?.AgentId == agentTeamId && ticket.TicketAssignment?.TeamId == null)
+                    {
+                        assignedToAgentNoTeam.Add(ticket);
                     }
                     /// Ticket is open and not assigned to a team/agent
                     else if (ticket.TicketAssignment == null && ticket.StatusType.StatusName != "Resolved" && ticket.StatusType.StatusName != "Closed")

--- a/ASI.Basecode.Services/Services/TicketService.cs
+++ b/ASI.Basecode.Services/Services/TicketService.cs
@@ -245,19 +245,6 @@ namespace ASI.Basecode.Services.Services
         }
 
         /// <summary>
-        /// Extracts the agent identifier from the assignment identifier.
-        /// </summary>
-        /// <param name="assignmentId">The assignment identifier</param>
-        /// <returns>string UserId</returns>
-        private string ExtractAgentId(string assignmentId)
-        {
-            if (string.IsNullOrEmpty(assignmentId)) return string.Empty;
-
-            string[] parts = assignmentId.Split('-');
-            return parts.Length >= 5 ? string.Join("-", parts.Take(5)) : assignmentId;
-        }
-
-        /// <summary>
         /// Helper method to update the ticket resolved date based on status.
         /// </summary>
         /// <param name="ticket">The ticket</param>

--- a/ASI.Basecode.Services/Services/UserService.cs
+++ b/ASI.Basecode.Services/Services/UserService.cs
@@ -301,7 +301,7 @@ namespace ASI.Basecode.Services.Services
 
             if (user != null)
             {
-                var teamMember = _teamRepository.FindTeamMemberByIdAsync(userId).Result;
+                /*var teamMember = _teamRepository.FindTeamMemberByIdAsync(userId).Result;
                 var tickets = _teamRepository.GetResolvedTicketsAssignedToTeamAsync(teamMember.TeamId).Result;
                 var feedbacks = tickets
                 .Where(t => t.Feedback != null)
@@ -323,10 +323,10 @@ namespace ASI.Basecode.Services.Services
                             Feedbacks = feedbacks
                         };
                     }
-                }
+                }*/
             }
             return null;
-        }
+        } // TODO: Implement this method
 
         private double CalculateAverageRating(List<Ticket> tickets)
         {

--- a/ASI.Basecode.WebApp/Controllers/TeamController.cs
+++ b/ASI.Basecode.WebApp/Controllers/TeamController.cs
@@ -20,6 +20,7 @@ namespace ASI.Basecode.WebApp.Controllers
     public class TeamController : ControllerBase<TeamController>
     {
         private readonly ITeamService _teamService;
+        private readonly ITicketService _ticketService;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TeamController"/> class.
@@ -37,12 +38,15 @@ namespace ASI.Basecode.WebApp.Controllers
             IConfiguration configuration,
             IMapper mapper,
             ITeamService teamService,
+            ITicketService ticketService,
             TokenValidationParametersFactory tokenValidationParametersFactory,
             TokenProviderOptionsFactory tokenProviderOptionsFactory) : base(httpContextAccessor, loggerFactory, configuration, mapper)
         {
             this._teamService = teamService;
+            this._ticketService = ticketService;
         }
 
+        #region GET Methods 
         /// <summary>Show all teams</summary>
         [Authorize(Policy = "Admin")]
         public async Task<IActionResult> ViewAll(string sortBy, string filterBy, int pageIndex = 1)
@@ -53,12 +57,14 @@ namespace ASI.Basecode.WebApp.Controllers
 
                 ViewData["FilterBy"] = filterBy;
                 ViewData["SortBy"] = sortBy;
+                ViewBag.CTs = (await _ticketService.GetCategoryTypesAsync())
+                                .Where(ct => !ct.CategoryName.Contains("Other"))
+                                .OrderBy(ct => ct.CategoryName).ToList();
 
                 return View(teams);
             }, "ViewAll");
         }
-
-        #region GET Methods        
+               
         /// <summary>
         /// Views the selected team.
         /// </summary>
@@ -79,6 +85,9 @@ namespace ASI.Basecode.WebApp.Controllers
                 ViewBag.AssignedAgents = agents.Where(x => x.TeamMember?.TeamId == id).ToList();
                 ViewBag.UnassignedAgents = agents.Where(x => x.TeamMember == null).ToList();
                 ViewBag.Teams = teams.Where(x => x.TeamId != id).ToList();
+                ViewBag.CTs = (await _ticketService.GetCategoryTypesAsync())
+                                .Where(ct => !ct.CategoryName.Contains("Other"))
+                                .OrderBy(ct => ct.CategoryName).ToList();
 
                 return View(team);
             }, "ViewTeam");

--- a/ASI.Basecode.WebApp/Startup.AutoMapper.cs
+++ b/ASI.Basecode.WebApp/Startup.AutoMapper.cs
@@ -31,9 +31,8 @@ namespace ASI.Basecode.WebApp
                 CreateMap<TicketViewModel, Ticket>();
                 CreateMap<Ticket, TicketViewModel>()
                         .ForMember(dest => dest.Attachment, opt => opt.MapFrom(src => src.Attachments.FirstOrDefault()))
-                        .ForMember(dest => dest.Agent, opt => opt.MapFrom(src => src.TicketAssignment != null
-                            ? src.TicketAssignment.Team.TeamMembers.FirstOrDefault(tm => tm.User.RoleId == "Support Agent").User
-                            : null))
+                        .ForMember(dest => dest.Agent, opt => opt.MapFrom(src => src.TicketAssignment != null ? src.TicketAssignment.Agent : null))
+                        .ForMember(dest => dest.Team, opt => opt.MapFrom(src => src.TicketAssignment != null ? src.TicketAssignment.Team : null))
                         .ForMember(dest => dest.TicketAssignment, opt => opt.MapFrom(src => src.TicketAssignment))
                         .ForMember(dest => dest.Feedback, opt => opt.MapFrom(src => src.Feedback))
                         .ForMember(dest => dest.Comments, opt => opt.MapFrom(src => src.Comments));

--- a/ASI.Basecode.WebApp/Views/Shared/_DeleteModal.cshtml
+++ b/ASI.Basecode.WebApp/Views/Shared/_DeleteModal.cshtml
@@ -1,13 +1,16 @@
 ﻿<div class="modal fade" id="deleteModal">
-    <div class="modal-dialog">
+    <div class="modal-dialog modal-dialog-centered">
         <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title" id="deleteModalLabel">Confirm Delete</h5>
+            <div class="modal-header border-0">
+                <h5 class="modal-title" id="deleteModalLabel">
+                    <i class="fa fa-exclamation-triangle px-1" style="color: var(--danger-color);"></i>
+                    Confirm Delete
+                </h5>
                 <button type="button" class="close" data-dismiss="modal">
                     <span>&times;</span>
                 </button>
             </div>
-            <div class="modal-body" id="deleteModalMessage">
+            <div class="modal-body pl-4 py-1" id="deleteModalMessage">
                 Are you sure you want to delete this item?
             </div>
             <div class="modal-footer">

--- a/ASI.Basecode.WebApp/Views/Team/ViewAll.cshtml
+++ b/ASI.Basecode.WebApp/Views/Team/ViewAll.cshtml
@@ -10,6 +10,7 @@
     int pageIndex = Model.PageIndex;
 
     string sortByName = string.IsNullOrEmpty(sortBy) ? "name_desc" : null;
+    string sortBySpecialization = sortBy == "specialization" ? "specialization_desc" : "specialization";
     string sortByNoOfAgents = sortBy == "agents" ? "agents_desc" : "agents";
     string sortByActiveTickets = sortBy == "active" ? "active_desc" : "active";
     string sortByInactiveTickets = sortBy == "inactive" ? "inactive_desc" : "inactive";
@@ -22,7 +23,7 @@
     <div class="d-flex justify-content-between">
         <form method="get" asp-action="ViewAll" asp-route-sortBy="@sortByName" asp-route-filterBy="@filterBy">
             <div class="form-group input-group">
-                <input type="text" name="filterBy" class="form-control btn-radius px-3" placeholder="Name or description" value="@filterBy" />
+                <input type="text" name="filterBy" class="form-control btn-radius px-3" placeholder="Name or specialization" value="@filterBy" />
                 <span class="input-group-append">
                     <button type="submit" class="btn btn-primary btn-radius-r px-3">
                         <i class="fa fa-search"></i>
@@ -55,7 +56,10 @@
                     </a>
                 </th>
                 <th>
-                    @Html.DisplayNameFor(model => model.First().Description)
+                    <a asp-action="ViewAll" asp-route-sortBy="@sortBySpecialization" asp-route-filterBy="@filterBy" asp-route-pageIndex="@pageIndex" class="text-black">
+                        @Html.DisplayNameFor(model => model.First().Specialization)
+                        @(sortBy == "specialization" ? Html.Raw("<i class='fa-solid fa-sort-up'></i>") : (sortBy == "specialization_desc" ? Html.Raw("<i class='fa-solid fa-sort-down'></i>") : Html.Raw("<i class='fa-solid fa-sort'></i>")))
+                    </a>
                 </th>
                 <th>
                     <a asp-action="ViewAll" asp-route-sortBy="@sortByNoOfAgents" asp-route-filterBy="@filterBy" asp-route-pageIndex="@pageIndex" class="text-black">
@@ -108,18 +112,7 @@
                                 @Html.DisplayFor(modelItem => item.Name)
                             </td>
                             <td>
-                                @{
-                                    var description = item.Description;
-                                    if (description != null && description.Length > 20)
-                                    {
-                                        description = description.Substring(0, 20) + "...";
-                                    }
-                                    else if (description == null)
-                                    {
-                                        description = "No description.";
-                                    }
-                                }
-                                @description
+                                @Html.DisplayFor(modelItem => item.Specialization.CategoryName)
                             </td>
                             <td>
                                 @(item.TeamMembers?.Count() ?? 0)

--- a/ASI.Basecode.WebApp/Views/Team/ViewTeam.cshtml
+++ b/ASI.Basecode.WebApp/Views/Team/ViewTeam.cshtml
@@ -1,4 +1,5 @@
 ﻿@model ASI.Basecode.Services.ServiceModels.TeamViewModel
+@using ASI.Basecode.Services.ServiceModels;
 
 @{
     ViewData["Title"] = "ViewTeam";
@@ -23,14 +24,14 @@
             <div class="row">
                 <div class="col-md-6">
                     <div class="form-group">
-                        <label asp-for="TeamId" class="control-label"></label>
-                        <input value="@Model.TeamId" class="form-control" readonly />
+                        <label asp-for="Name" class="control-label"></label>
+                        <input value="@Model.Name" class="form-control" readonly />
                     </div>
                 </div>
                 <div class="col-md-6">
                     <div class="form-group">
-                        <label asp-for="Name" class="control-label"></label>
-                        <input value="@Model.Name" class="form-control" readonly />
+                        <label asp-for="Specialization" class="control-label"></label>
+                        <input value="@Model.Specialization.CategoryName" class="form-control" readonly />
                     </div>
                 </div>
             </div>

--- a/ASI.Basecode.WebApp/Views/Team/ViewTeam.cshtml
+++ b/ASI.Basecode.WebApp/Views/Team/ViewTeam.cshtml
@@ -115,8 +115,6 @@
 @section Scripts {
     <script src="~/js/team.js"></script>
     <script src="~/js/toastrNotification.js"></script>
-    <script src="~/lib/jquery/jquery.min.js"></script>
-    <script src="~/lib/bootstrap/js/bootstrap.bundle.min.js"></script>
     <script>
         function displayPerformanceReport(userId) {
             var url = '@Url.Action("PerformanceReport", "User")?userId=' + userId;

--- a/ASI.Basecode.WebApp/Views/Team/_CreateTeamModal.cshtml
+++ b/ASI.Basecode.WebApp/Views/Team/_CreateTeamModal.cshtml
@@ -1,5 +1,9 @@
 ﻿@model ASI.Basecode.Services.ServiceModels.TeamViewModel
 
+@{
+    var CategoryTypes = ViewBag.CTs;
+}
+
 <div class="modal fade" id="createTeamModal" tabindex="-1" role="dialog" aria-labelledby="createTeamModalLabel" aria-hidden="true">
     <div class="modal-dialog" role="document">
         <div class="modal-content">
@@ -21,6 +25,15 @@
                         <label asp-for="Description" class="control-label"></label>
                         <textarea asp-for="Description" class="form-control" id="createTeamDescription" name="Description"></textarea>
                         <span asp-validation-for="Description" class="text-danger"></span>
+                    </div>
+                    <div class="form-group">
+                        <label asp-for="SpecializationId" class="control-label"></label>
+                        <select asp-for="SpecializationId" class="form-control">
+                            @foreach (var item in CategoryTypes)
+                            {
+                                <option value="@item.CategoryTypeId">@item.CategoryName</option>
+                            }
+                        </select>
                     </div>
                 </form>
             </div>

--- a/ASI.Basecode.WebApp/Views/Team/_EditTeamModal.cshtml
+++ b/ASI.Basecode.WebApp/Views/Team/_EditTeamModal.cshtml
@@ -1,5 +1,9 @@
 ﻿@model ASI.Basecode.Services.ServiceModels.TeamViewModel
 
+@{
+    var CategoryTypes = ViewBag.CTs;
+}
+
 <div class="modal fade" id="editTeamModal" tabindex="-1" role="dialog" aria-labelledby="editTeamModalLabel" aria-hidden="true">
     <div class="modal-dialog" role="document">
         <div class="modal-content">
@@ -21,6 +25,15 @@
                         <label asp-for="Description" class="control-label"></label>
                         <textarea asp-for="Description" class="form-control" id="editTeamDescription" name="Description"></textarea>
                         <span asp-validation-for="Description" class="text-danger"></span>
+                    </div>
+                    <div class="form-group">
+                        <label asp-for="SpecializationId" class="control-label"></label>
+                        <select asp-for="SpecializationId" class="form-control">
+                            @foreach (var item in CategoryTypes)
+                            {
+                                <option value="@item.CategoryTypeId">@item.CategoryName</option>
+                            }
+                        </select>
                     </div>
                 </form>
             </div>

--- a/ASI.Basecode.WebApp/Views/Team/_ReassignAgentModal.cshtml
+++ b/ASI.Basecode.WebApp/Views/Team/_ReassignAgentModal.cshtml
@@ -1,4 +1,9 @@
 ﻿@model ASI.Basecode.Services.ServiceModels.TeamViewModel
+@using ASI.Basecode.Data.Models;
+
+@{
+    var teams = ViewBag.Teams as List<Team>;
+}
 
 <div class="modal fade" id="reassignAgentModal" tabindex="-1" role="dialog" aria-labelledby="reassignAgentModalLabel" aria-hidden="true">
     <div class="modal-dialog" role="document">
@@ -17,9 +22,14 @@
                         <label for="newTeamId" class="control-label">Select New Team</label>
                         <select id="newTeamId" name="newTeamId" class="form-control">
                             <option value="">-- Unassign --</option>
-                            @foreach (var team in ViewBag.Teams)
+                            @foreach (var teamGroup in teams.OrderBy(t => t.Specialization.CategoryName).GroupBy(t => t.Specialization.CategoryName))
                             {
-                                <option value="@team.TeamId">@team.Name</option>
+                                <optgroup label="@teamGroup.Key">
+                                    @foreach(var team in teamGroup)
+                                    {
+                                        <option value="@team.TeamId">@team.Name</option>
+                                    }
+                                </optgroup>
                             }
                         </select>
                     </div>

--- a/ASI.Basecode.WebApp/Views/Ticket/ViewTicket.cshtml
+++ b/ASI.Basecode.WebApp/Views/Ticket/ViewTicket.cshtml
@@ -77,10 +77,20 @@
             </div>
             <div class="pb-4 text-muted d-flex justify-content-between">
                 <div class="my-0">
-                    @Html.DisplayNameFor(model => model.TicketAssignment):
-                    @if (Model.TicketAssignment == null)
+                    @Html.DisplayNameFor(model => model.Team):
+                    @if (Model.TicketAssignment?.Team == null)
                     {
-                        @:No Assignee
+                        @:--Unavailable--
+                    }
+                    else
+                    {
+                        @Html.DisplayFor(model => model.Team.Name)
+                    }
+                    <br />
+                    @Html.DisplayNameFor(model => model.Agent):
+                    @if (Model.TicketAssignment?.Agent == null)
+                    {
+                        @:--Unavailable--
                     }
                     else
                     {
@@ -192,7 +202,50 @@
         var addCommentUrl = '@Url.Action("AddComment", "Ticket")';
         var deleteCommentUrl = '@Url.Action("DeleteComment", "Ticket")';
         var ticketId = '@Model.TicketId';
+
+        $('#teamId').change(function () {
+            var selectedTeamMembers = $('#teamId option:selected').data('team-members');
+            var agentDropdown = $('#agentId');
+            var currentAgentId = $('#currentAgentId').val();
+            var agentFound = false;
+
+            agentDropdown.empty();
+
+            if (!selectedTeamMembers || selectedTeamMembers.length === 0) {
+                agentDropdown.append('<option value="no_agent">-- No agents available --</option>');
+                agentDropdown.prop('disabled', true);
+            } else {
+                selectedTeamMembers.forEach(function (member) {
+                    if (member.UserId == currentAgentId) {
+                        agentFound = true;
+                    }
+                });
+
+                if (agentFound) {
+                    agentDropdown.append('<option value="no_agent">-- Unassign Agent --</option>');
+                } else {
+                    agentDropdown.append(`<option value="no_agent">-- Select Agent: ${selectedTeamMembers.length} Available --</option>`);
+                }
+
+                selectedTeamMembers.forEach(function (member) {
+                    agentDropdown.append('<option value="' + member.UserId + '">' + member.UserName + '</option>');
+                });
+
+                agentDropdown.prop('disabled', false);
+            }
+
+            if (currentAgentId && agentFound) {
+                agentDropdown.val(currentAgentId);
+            } else {
+                agentDropdown.val("no_agent");
+            }
+        });
+
+        $('#teamId').trigger('change');
     </script>
+
+
+
     <script src="~/js/comment.js"></script>
     <script src="~/js/feedback.js"></script>
     <script src="~/js/toastrNotification.js"></script>

--- a/ASI.Basecode.WebApp/Views/Ticket/_UpdateAssignmentModal.cshtml
+++ b/ASI.Basecode.WebApp/Views/Ticket/_UpdateAssignmentModal.cshtml
@@ -4,7 +4,7 @@
     <div class="modal-dialog modal-dialog-centered" role="document">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title" id="updateAssignmentModalLabel">TICKET ID #@Model.TicketId</h5>
+                <h5 class="modal-title font-weight-bold" id="updateAssignmentModalLabel">TICKET ID #@Model.TicketId</h5>
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                     <span aria-hidden="true">&times;</span>
                 </button>
@@ -12,16 +12,30 @@
             <div class="modal-body">
                 <form id="updateAssignmentForm">
                     <div class="form-group">
-                        <label for="agentId" class="control-label">Assignee</label>
-                        <select asp-for="Agent.UserId" id="agentId" class="form-control">
-                            <option value="remove">@(string.IsNullOrEmpty(Model.Agent?.UserId) ? "-- Assign --" : "-- Unassign --")</option>
-                            @foreach (var item in Model.Agents)
+                        <label for="teamId" class="control-label">Team</label>
+                        <select asp-for="Team.TeamId" id="teamId" class="form-control">
+                            <option value="no_team" data-team-members='@Html.Raw(Newtonsoft.Json.JsonConvert.SerializeObject(Model.AgentsWithNoTeam.Select(tm => new { tm.UserId, UserName = tm.Name })))'>@(string.IsNullOrEmpty(Model.Team?.TeamId) ? "-- No Team --" : "-- Unassign --")</option>
+                            @foreach (var teamGroup in Model.Teams.OrderBy(t => t.Specialization.CategoryName).GroupBy(t => t.Specialization.CategoryName))
                             {
-                                <option value="@item.UserId">@item.Name</option>
+                                <optgroup label="@teamGroup.Key">
+                                    @foreach (var team in teamGroup)
+                                    {
+                                        <option value="@team.TeamId" data-team-members='@Html.Raw(Newtonsoft.Json.JsonConvert.SerializeObject(team.TeamMembers.Select(tm => new { tm.UserId, UserName = tm.User.Name })))'>
+                                            @team.Name
+                                        </option>
+                                    }
+                                </optgroup>
                             }
                         </select>
                     </div>
+                    <div class="form-group">
+                        <label for="agentId" class="control-label">Agent</label>
+                        <select asp-for="Agent.UserId" id="agentId" class="form-control">
+                            <option value="remove">@(string.IsNullOrEmpty(Model.Agent?.UserId) ? "-- Assign --" : "-- Unassign --")</option>
+                        </select>
+                    </div>
                     <input type="hidden" id="ticketId" value="@Model.TicketId" />
+                    <input type="hidden" id="currentAgentId" value="@Model.Agent?.UserId" />
                 </form>
             </div>
             <div class="modal-footer">

--- a/ASI.Basecode.WebApp/Views/User/Index.cshtml
+++ b/ASI.Basecode.WebApp/Views/User/Index.cshtml
@@ -112,14 +112,13 @@
                             {
                                 <a href="javascript:void(0);" class="fas fa-edit action-icon" data-toggle="modal" data-target="#editUserModal" data-userid="@item.UserId" data-toggle="tooltip" title="Edit"></a>
                             }
-
                             <text> | </text>
                             @Html.ActionLink("", "Details", new { SelectedUserId = item.UserId }, new { @class = "fas fa-info-circle action-icon", data_toggle = "modal", data_target = "#userDetailsModal-" + @item.UserId })
                             @if (isSuper || item.RoleId != "Admin")
                             {
                                 <text> | </text>
                                 <a href="javascript:void(0);" onclick="displayDeleteModal('@item.UserId')" class="fas fa-trash-alt action-icon"></a>
-
+                            }
                             @if (item.RoleId.Equals("Support Agent"))
                             {
                                 <button type="button" class="btn btn-secondary btn-sm" data-toggle="modal" data-target="#performanceReportModal" data-userid="@item.UserId" data-toggle="tooltip" title="View Performance">
@@ -127,7 +126,6 @@
                                 </button>
                             }
                         </td>
-
                     </tr>
                 }
             </tbody>

--- a/ASI.Basecode.WebApp/appsettings.json
+++ b/ASI.Basecode.WebApp/appsettings.json
@@ -5,7 +5,7 @@
   },
   "ConnectionStrings": {
 
-    "DefaultConnection": "Addr=FRIESDEVOURER;database=AsiBasecodeDb;Integrated Security=False;Trusted_Connection=True;MultipleActiveResultSets=True;"
+    "DefaultConnection": "Addr=localhost;database=AsiBasecodeDb;Integrated Security=False;Trusted_Connection=True;MultipleActiveResultSets=True;"
   },
   "Logging": {
     "LogLevel": {

--- a/ASI.Basecode.WebApp/wwwroot/js/delete.js
+++ b/ASI.Basecode.WebApp/wwwroot/js/delete.js
@@ -2,7 +2,7 @@
 function displayDeleteModal(id, name) {
     itemId = id;
     itemName = name;
-    document.getElementById('deleteModalMessage').textContent = `Are you sure you want to delete ${itemName}?`;
+    document.getElementById('deleteModalMessage').textContent = `Are you sure you want to delete ${itemName}? This action is permanent and cannot be undone.`;
     $('#deleteModal').modal('show');
 }
 

--- a/ASI.Basecode.WebApp/wwwroot/js/ticket.js
+++ b/ASI.Basecode.WebApp/wwwroot/js/ticket.js
@@ -154,6 +154,7 @@ function saveTracking() {
 }
 
 $('#saveAssignmentBtn').click(function () {
+    var teamId = $('#teamId').val();
     var agentId = $('#agentId').val();
     var ticketId = $('#ticketId').val();
 
@@ -163,6 +164,7 @@ $('#saveAssignmentBtn').click(function () {
         contentType: 'application/json',
         data: JSON.stringify({
             TicketId: ticketId,
+            TeamId: teamId,
             AgentId: agentId,
         }),
         success: function (response) {


### PR DESCRIPTION
Model updates
- TicketAssignment: assigned by: changed from admin to user to allow agents to reassign tickets
- TicketAssignment: added AgentId to allow direct agent assignment instead of needing team
- TicketAssignment: modified database to allow agent or team to be null
- Team: added specialization to allow access to tickets under the same category type

Ticket updates
- enabled ticket assignment to either team or agent, or both
- added dynamic dropdown for team/agent assignments in _UpdateAssignmentModal

Team updates
- added specialization and name search for team
- removed description from view all, replaced with specialization
- when agent is reassigned to another team or removed from team, ticket assignment will remain with original team
- when agent is assigned to new team from no team, ticket assignment will move to the new team