### PR TITLE
Ticket and team modifications

### DIFF
--- a/ASI.Basecode.Data/Interfaces/ITicketRepository.cs
+++ b/ASI.Basecode.Data/Interfaces/ITicketRepository.cs
@@ -8,10 +8,11 @@ namespace ASI.Basecode.Data.Interfaces
     public interface ITicketRepository
     {
         Task<List<Ticket>> GetAllAsync();
-        Task<List<Ticket>> GetAllAndDeletedAsync();
+        Task<int> CountAllAndDeletedTicketsAsync();
         Task AddAsync(Ticket ticket);
         Task UpdateAsync(Ticket ticket);
         Task DeleteAsync(Ticket ticket);
+        Task DeleteHardAsync(Ticket ticket);
         Task AddAttachmentAsync(Attachment attachment);
         Task RemoveAttachmentAsync(Attachment attachment);
         Task AssignTicketAsync(TicketAssignment assignment);

--- a/ASI.Basecode.Data/Repositories/TeamRepository.cs
+++ b/ASI.Basecode.Data/Repositories/TeamRepository.cs
@@ -133,6 +133,7 @@ namespace ASI.Basecode.Data.Repositories
                         .Include(u => u.ActivityLogs)
                         .Include(u => u.KnowledgeBaseArticles)
                         .Include(u => u.TicketAssignmentAgents)
+                            .ThenInclude(ta => ta.Ticket)
                         .FirstOrDefaultAsync(u => u.UserId == id);
         }
 

--- a/ASI.Basecode.Data/Repositories/TicketRepository.cs
+++ b/ASI.Basecode.Data/Repositories/TicketRepository.cs
@@ -45,12 +45,27 @@ namespace ASI.Basecode.Data.Repositories
                         .ThenInclude(ta => ta.Team);
         }
 
+        private IQueryable<Ticket> GetTicketsWithLimitedIncludes()
+        {
+            return this.GetDbSet<Ticket>()
+                    .Where(t => !t.IsDeleted)
+                    .Include(t => t.CategoryType)
+                    .Include(t => t.PriorityType)
+                    .Include(t => t.StatusType)
+                    .Include(t => t.User)
+                    .Include(t => t.Feedback)
+                    .Include(t => t.TicketAssignment)
+                        .ThenInclude(ta => ta.Agent)
+                    .Include(t => t.TicketAssignment)
+                        .ThenInclude(ta => ta.Team);
+        }
+
         /// <summary>
         /// Get all tickets
         /// </summary>
         /// <returns>List Ticket</returns>
         public async Task<List<Ticket>> GetAllAsync() =>
-            await GetTicketsWithIncludes().AsNoTracking().ToListAsync();
+            await GetTicketsWithLimitedIncludes().AsNoTracking().ToListAsync();
 
         /// <summary>
         /// Gets all tickets including the deleted.

--- a/ASI.Basecode.Data/Repositories/TicketRepository.cs
+++ b/ASI.Basecode.Data/Repositories/TicketRepository.cs
@@ -56,27 +56,8 @@ namespace ASI.Basecode.Data.Repositories
         /// Gets all tickets including the deleted.
         /// </summary>
         /// <returns>List Ticket</returns>
-        public Task<List<Ticket>> GetAllAndDeletedAsync()
-        {
-            return this.GetDbSet<Ticket>()
-                    .Include(t => t.CategoryType)
-                    .Include(t => t.PriorityType)
-                    .Include(t => t.StatusType)
-                    .Include(t => t.User)
-                    .Include(t => t.Feedback)
-                    .Include(t => t.Attachments)
-                    .Include(t => t.Comments)
-                        .ThenInclude(cu => cu.User)
-                    .Include(t => t.Comments)
-                        .ThenInclude(cp => cp.Parent)
-                    .Include(t => t.Comments)
-                        .ThenInclude(c => c.InverseParent)
-                    .Include(t => t.TicketAssignment)
-                        .ThenInclude(ta => ta.Team)
-                        .ThenInclude(team => team.TeamMembers)
-                        .ThenInclude(tm => tm.User)
-                    .AsNoTracking().ToListAsync();
-        }
+        public async Task<int> CountAllAndDeletedTicketsAsync() =>
+            await this.GetDbSet<Ticket>().AsNoTracking().CountAsync();
 
         /// <summary>
         /// Add a ticket
@@ -106,6 +87,21 @@ namespace ASI.Basecode.Data.Repositories
         {
             ticket.IsDeleted = true;
             this.GetDbSet<Ticket>().Update(ticket);
+            await UnitOfWork.SaveChangesAsync();
+        }
+
+        /// <summary>
+        /// Hard delete a ticket
+        /// </summary>
+        /// <param name="ticket">The ticket</param>
+        public async Task DeleteHardAsync(Ticket ticket)
+        {
+            ticket.CategoryTypeId = null;
+            ticket.PriorityTypeId = null;
+            ticket.StatusTypeId = null;
+            ticket.UserId = null;
+
+            this.GetDbSet<Ticket>().Remove(ticket);
             await UnitOfWork.SaveChangesAsync();
         }
         #endregion Ticket Service Methods

--- a/ASI.Basecode.Services/Interfaces/ITicketService.cs
+++ b/ASI.Basecode.Services/Interfaces/ITicketService.cs
@@ -20,7 +20,7 @@ namespace ASI.Basecode.Services.Interfaces
         Task<List<TicketViewModel>> GetAllAsync();
         Task<TicketViewModel> GetTicketByIdAsync(string id);
         Task<TicketViewModel> GetFilteredTicketByIdAsync(string id);
-        Task<PaginatedList<TicketViewModel>> GetFilteredAndSortedTicketsAsync(string sortBy, string filterBy, string filterValue, int pageIndex, int pageSize);
+        Task<PaginatedList<TicketViewModel>> GetFilteredAndSortedTicketsAsync(string sortBy, string filterBy, string filterValue, string search, int pageIndex, int pageSize);
         Task<Attachment> GetAttachmentByTicketIdAsync(string id);
         Task<TicketAssignment> GetAssignmentByTicketIdAsync(string id);
         Task<Team> GetTeamByUserIdAsync(string id);

--- a/ASI.Basecode.Services/Interfaces/ITicketService.cs
+++ b/ASI.Basecode.Services/Interfaces/ITicketService.cs
@@ -19,6 +19,7 @@ namespace ASI.Basecode.Services.Interfaces
         Task DeleteCommentAsync(string commentId);
         Task<List<TicketViewModel>> GetAllAsync();
         Task<TicketViewModel> GetTicketByIdAsync(string id);
+        Task<TicketViewModel> GetFilteredTicketByIdAsync(string id);
         Task<PaginatedList<TicketViewModel>> GetFilteredAndSortedTicketsAsync(string sortBy, string filterBy, string filterValue, int pageIndex, int pageSize);
         Task<Attachment> GetAttachmentByTicketIdAsync(string id);
         Task<TicketAssignment> GetAssignmentByTicketIdAsync(string id);

--- a/ASI.Basecode.Services/Services/TeamService.cs
+++ b/ASI.Basecode.Services/Services/TeamService.cs
@@ -161,6 +161,7 @@ namespace ASI.Basecode.Services.Services
                 var model = new TicketViewModel();
                 foreach (var ticketAssignment in agent.TicketAssignmentAgents)
                 {
+                    if (ticketAssignment.Ticket.StatusTypeId == "S3") continue;
                     model.AgentId = agentId;
                     model.TicketId = ticketAssignment.TicketId;
                     model.TeamId = teamId;
@@ -199,6 +200,7 @@ namespace ASI.Basecode.Services.Services
                 var model = new TicketViewModel();
                 foreach(var ticketAssignment in agent.TicketAssignmentAgents)
                 {
+                    if (ticketAssignment.Ticket.StatusTypeId == "S3") continue;
                     model.AgentId = "no_agent";
                     model.TicketId = ticketAssignment.TicketId;
                     model.TeamId = ticketAssignment.TeamId;

--- a/ASI.Basecode.Services/Services/TicketService.Assignment.cs
+++ b/ASI.Basecode.Services/Services/TicketService.Assignment.cs
@@ -26,13 +26,14 @@ namespace ASI.Basecode.Services.Services
         /// ------------------------------
         /// existing assignment
         /// case 0: same team, same agent - exception
-        /// case 1: no team, no agent
-        /// case 2: same team, no agent
-        /// case 3: no team, different agent
-        /// case 4: same team, different agent
-        /// case 5: different team, no agent
-        /// case 6: different team, different agent
-        /// case 7: new team from no team, same agent -> no team agent with ticket was assigned to a team
+        /// case 1: same team, no agent assigned, no agent selected - exception
+        /// case 2: no team, no agent
+        /// case 3: same team, no agent
+        /// case 4: no team, different agent
+        /// case 5: same team, different agent
+        /// case 6: different team, no agent
+        /// case 7: different team, different agent
+        /// case 8: new team from no team, same agent -> no team agent with ticket was assigned to a team
         public async Task<string> UpdateAssignmentAsync(TicketViewModel model)
         {
             var currentUser = _httpContextAccessor.HttpContext.User?.FindFirst(ClaimTypes.NameIdentifier)?.Value;
@@ -77,6 +78,10 @@ namespace ASI.Basecode.Services.Services
                 if (teamId == assignmentTeamId && agentId == assignmentAgentId)
                 {
                     throw new TicketException("Cannot reassign to the same team and agent.", ticketId);
+                }
+                if (teamId == assignmentTeamId && agentId == noAgent && assignmentAgentId == null)
+                {
+                    throw new TicketException("Cannot assign to the same team without an agent selected.", ticketId);
                 }
 
                 if (teamId == noTeam && agentId == noAgent)

--- a/ASI.Basecode.WebApp/Controllers/TeamController.cs
+++ b/ASI.Basecode.WebApp/Controllers/TeamController.cs
@@ -77,7 +77,18 @@ namespace ASI.Basecode.WebApp.Controllers
         {
             return await HandleExceptionAsync(async () =>
             {
+                if (string.IsNullOrEmpty(id))
+                {
+                    TempData["ErrorMessage"] = "Team ID is invalid!";
+                    return RedirectToAction("ViewAll");
+                }
+
                 var team = await _teamService.GetTeamByIdAsync(id);
+                if(team == null)
+                {
+                    TempData["ErrorMessage"] = "Team not found!";
+                    return RedirectToAction("ViewAll");
+                }
                 var agents = await _teamService.GetAgentsAsync();
                 var teams = await _teamService.GetAllStrippedAsync();
 

--- a/ASI.Basecode.WebApp/Controllers/TicketController.cs
+++ b/ASI.Basecode.WebApp/Controllers/TicketController.cs
@@ -87,27 +87,29 @@ namespace ASI.Basecode.WebApp.Controllers
         {
             return await HandleExceptionAsync(async () =>
             {
-                if (string.IsNullOrEmpty(id)) return RedirectToAction("ViewAll");
-                var ticket = await _ticketService.GetTicketByIdAsync(id);
-                if (ticket == null) return RedirectToAction("ViewAll");
-                var statusTypes = await _ticketService.GetStatusTypesAsync();
-                var agents = await _teamService.GetAgentsAsync();
-
-                ticket.StatusTypes = User.IsInRole("Employee") ? statusTypes.Where(x => x.StatusName != "Resolved" && x.StatusName != "In Progress") : 
-                        statusTypes.Where(x => x.StatusName != "Closed" && !(ticket.Agent == null && x.StatusName == "Resolved"));
-                ticket.PriorityTypes = await _ticketService.GetPriorityTypesAsync();
-                ticket.CategoryTypes = await _ticketService.GetCategoryTypesAsync();
-                ticket.Teams = await _teamService.GetAllStrippedAsync();
-                ticket.Agents = agents;
-                ticket.AgentsWithNoTeam = agents.Where(x => x.TeamMember == null);
-
-                if (!string.IsNullOrEmpty(notificationId))
+                if (string.IsNullOrEmpty(id))
                 {
-                    _notificationService.MarkNotificationAsRead(notificationId);
+                    TempData["ErrorMessage"] = "Ticket ID is invalid!";
+                    return RedirectToAction("ViewAll");
                 }
-                ticket.Comments = ticket.Comments?.OrderByDescending(c => c.PostedDate);
-                ViewBag.ShowModal = showModal;
-                return View(ticket);
+
+                var ticket = await _ticketService.GetFilteredTicketByIdAsync(id);
+                if (ticket == null)
+                {
+                    TempData["ErrorMessage"] = "Ticket not found!";
+                    return RedirectToAction("ViewAll");
+                }
+                if (ticket != null)
+                {
+                    ViewBag.ShowModal = showModal;
+                    ViewBag.UserId = UserId;
+                    if (!string.IsNullOrEmpty(notificationId))
+                    {
+                        _notificationService.MarkNotificationAsRead(notificationId);
+                    }
+                    return View(ticket);
+                }
+                return RedirectToAction("ViewAll");
             }, "ViewTicket");
         }
         #endregion GET methods
@@ -149,10 +151,10 @@ namespace ASI.Basecode.WebApp.Controllers
                 if (model != null)
                 {
                     await _ticketService.UpdateAsync(model,4);
-                    TempData["SuccessMessage"] = "Ticket edited successfully!";
+                    TempData["SuccessMessage"] = "Ticket updated successfully!";
                     return Json(new { success = true });
                 }
-                TempData["ErrorMessage"] = "An error occurred while editing the ticket. Please try again.";
+                TempData["ErrorMessage"] = "An error occurred while updating the ticket. Please try again.";
                 return Json(new { success = false });
             }, "Edit");
         }

--- a/ASI.Basecode.WebApp/Controllers/TicketController.cs
+++ b/ASI.Basecode.WebApp/Controllers/TicketController.cs
@@ -61,16 +61,17 @@ namespace ASI.Basecode.WebApp.Controllers
         /// <param name="filterValue">User defined, taken from the page</param>
         /// <returns>ViewAll page</returns>
         [Authorize]
-        public async Task<IActionResult> ViewAll(string sortBy, string filterBy, string filterValue, int pageIndex = 1)
+        public async Task<IActionResult> ViewAll(string sortBy, string filterBy, string filterValue, string search, int pageIndex = 1)
         {
             return await HandleExceptionAsync(async () =>
             {
                 await PopulateViewBagAsync();
-                var tickets = await _ticketService.GetFilteredAndSortedTicketsAsync(sortBy, filterBy, filterValue, pageIndex, 10);
+                var tickets = await _ticketService.GetFilteredAndSortedTicketsAsync(sortBy, filterBy, filterValue, search, pageIndex, 10);
 
                 ViewData["FilterBy"] = filterBy;
                 ViewData["FilterValue"] = filterValue;
                 ViewData["SortBy"] = sortBy;
+                ViewData["Search"] = search;
 
                 return View(tickets);
             }, "ViewAll");

--- a/ASI.Basecode.WebApp/Views/Team/ViewAll.cshtml
+++ b/ASI.Basecode.WebApp/Views/Team/ViewAll.cshtml
@@ -21,7 +21,7 @@
 <div class="d-flex justify-content-between nav-header">
     <h1 class="display-6">Team Management</h1>
     <div class="d-flex justify-content-between">
-        <form method="get" asp-action="ViewAll" asp-route-sortBy="@sortByName" asp-route-filterBy="@filterBy">
+        <form method="get" asp-action="ViewAll" asp-route-sortBy="@sortBy" asp-route-filterBy="@filterBy">
             <div class="form-group input-group">
                 <input type="text" name="filterBy" class="form-control btn-radius px-3" placeholder="Name or specialization" value="@filterBy" />
                 <span class="input-group-append">
@@ -30,6 +30,7 @@
                     </button>
                 </span>
             </div>
+            <input type="hidden" name="sortBy" value="@sortBy" />
         </form>
         <div class="mx-3">
             <p>

--- a/ASI.Basecode.WebApp/Views/Ticket/ViewAll.cshtml
+++ b/ASI.Basecode.WebApp/Views/Ticket/ViewAll.cshtml
@@ -8,6 +8,7 @@
     string filterBy = ViewData["FilterBy"] as string;
     string filterValue = ViewData["FilterValue"] as string;
     string sortBy = ViewData["SortBy"] as string;
+    string search = ViewData["Search"] as string;
     int pageIndex = Model.PageIndex;
 
     string sortById = string.IsNullOrEmpty(sortBy) ? "id_desc" : null;
@@ -25,20 +26,37 @@
     var categoryTypes = ViewBag.CategoryTypes as List<string>;
     var users = ViewBag.Users as List<string>;
 }
-
-<h1 class="nav-header display-6">Tickets</h1>
+<div class="d-flex justify-content-between nav-header">
+    <h1 class="display-6">Tickets</h1>
+    <div class="d-flex justify-content-between">
+        <form method="get" asp-action="ViewAll" asp-route-sortBy="@sortBy" asp-route-filterBy="@filterBy" asp-route-filterValue="@filterValue" asp-route-search="@search">
+            <div class="form-group input-group">
+                <input type="text" name="search" class="form-control btn-radius px-3" placeholder="Search by subject" value="@search" />
+                <span class="input-group-append">
+                    <button type="submit" class="btn btn-primary btn-radius-r px-3">
+                        <i class="fa fa-search"></i>
+                    </button>
+                </span>
+            </div>
+            <input type="hidden" name="sortBy" value="@sortBy" />
+            <input type="hidden" name="filterBy" value="@filterBy" />
+            <input type="hidden" name="filterValue" value="@filterValue" />
+        </form>
+        <div class="mx-3">
+            <p>
+                @if (User.IsInRole("Employee"))
+                {
+                    <button type="button" class="btn btn-primary btn-radius" data-toggle="modal" data-target="#createTicketModal">
+                        <i class="fa fa-plus"></i>
+                        Create Ticket
+                    </button>
+                }
+            </p>
+        </div>
+    </div>
+</div>
 
 <div class="container-fluid px-4 py-3">
-    <p>
-        @if (User.IsInRole("Employee"))
-        {
-            <button type="button" class="btn btn-primary btn-radius" data-toggle="modal" data-target="#createTicketModal">
-                <i class="fa fa-plus"></i>
-                Create Ticket
-            </button>
-        }
-    </p>
-
     <form method="get" asp-action="ViewAll">
         <label for="filterBy">Filter By: </label>
         <select asp-for="@filterBy" id="filterBy" name="filterBy">
@@ -50,6 +68,8 @@
         </select>
         <select id="filterValue" name="filterValue" style="display: none;"></select>
         <button type="submit" class="btn btn-primary">Apply Filter</button>
+        <input type="hidden" name="sortBy" value="@sortBy" />
+        <input type="hidden" name="search" value="@search" />
     </form>
 
     <div class="py-3">
@@ -58,13 +78,13 @@
                 <tr>
                     <th>
 
-                        <a asp-action="ViewAll" asp-route-sortBy="@sortById" asp-route-filterBy="@filterBy" asp-route-filterValue="@filterValue" asp-route-pageIndex="@pageIndex" class="text-black">
+                        <a asp-action="ViewAll" asp-route-sortBy="@sortById" asp-route-filterBy="@filterBy" asp-route-filterValue="@filterValue" asp-route-pageIndex="@pageIndex" asp-route-search="@search" class="text-black">
                             @Html.DisplayNameFor(model => model.First().TicketId)
                             @(string.IsNullOrEmpty(sortBy) ? Html.Raw("<i class='fa-solid fa-sort-up'></i>") : (sortBy == "id_desc" ? Html.Raw("<i class='fa-solid fa-sort-down'></i>") : Html.Raw("<i class='fa-solid fa-sort'></i>")))
                         </a>
                     </th>
                     <th>
-                        <a asp-action="ViewAll" asp-route-sortBy="@sortBySubject" asp-route-filterBy="@filterBy" asp-route-filterValue="@filterValue" asp-route-pageIndex="@pageIndex" class="text-black">
+                        <a asp-action="ViewAll" asp-route-sortBy="@sortBySubject" asp-route-filterBy="@filterBy" asp-route-filterValue="@filterValue" asp-route-pageIndex="@pageIndex" asp-route-search="@search" class="text-black">
                             @Html.DisplayNameFor(model => model.First().Subject)
                             @(sortBy == "subject" ? Html.Raw("<i class='fa-solid fa-sort-up'></i>") : (sortBy == "subject_desc" ? Html.Raw("<i class='fa-solid fa-sort-down'></i>") : Html.Raw("<i class='fa-solid fa-sort'></i>")))
                         </a>
@@ -72,44 +92,44 @@
                     @if (!User.IsInRole("Employee"))
                     {
                         <th>
-                            <a asp-action="ViewAll" asp-route-sortBy="@sortByUser" asp-route-filterBy="@filterBy" asp-route-filterValue="@filterValue" asp-route-pageIndex="@pageIndex" class="text-black">
+                            <a asp-action="ViewAll" asp-route-sortBy="@sortByUser" asp-route-filterBy="@filterBy" asp-route-filterValue="@filterValue" asp-route-pageIndex="@pageIndex" asp-route-search="@search" class="text-black">
                                 @Html.DisplayNameFor(model => model.First().User)
                                 @(sortBy == "user" ? Html.Raw("<i class='fa-solid fa-sort-up'></i>") : (sortBy == "user_desc" ? Html.Raw("<i class='fa-solid fa-sort-down'></i>") : Html.Raw("<i class='fa-solid fa-sort'></i>")))
                             </a>
                         </th>
                     }
                     <th>
-                        <a asp-action="ViewAll" asp-route-sortBy="@sortByUpdatedDate" asp-route-filterBy="@filterBy" asp-route-filterValue="@filterValue" asp-route-pageIndex="@pageIndex" class="text-black">
+                        <a asp-action="ViewAll" asp-route-sortBy="@sortByUpdatedDate" asp-route-filterBy="@filterBy" asp-route-filterValue="@filterValue" asp-route-pageIndex="@pageIndex" asp-route-search="@search" class="text-black">
                             @Html.DisplayNameFor(model => model.First().UpdatedDate)
                             @(sortBy == "updated" ? Html.Raw("<i class='fa-solid fa-sort-up'></i>") : (sortBy == "updated_desc" ? Html.Raw("<i class='fa-solid fa-sort-down'></i>") : Html.Raw("<i class='fa-solid fa-sort'></i>")))
                         </a>
                     </th>
                     <th>
-                        <a asp-action="ViewAll" asp-route-sortBy="@sortByResolvedDate" asp-route-filterBy="@filterBy" asp-route-filterValue="@filterValue" asp-route-pageIndex="@pageIndex" class="text-black">
+                        <a asp-action="ViewAll" asp-route-sortBy="@sortByResolvedDate" asp-route-filterBy="@filterBy" asp-route-filterValue="@filterValue" asp-route-pageIndex="@pageIndex" asp-route-search="@search" class="text-black">
                             @Html.DisplayNameFor(model => model.First().ResolvedDate)
                             @(sortBy == "resolved" ? Html.Raw("<i class='fa-solid fa-sort-up'></i>") : (sortBy == "resolved_desc" ? Html.Raw("<i class='fa-solid fa-sort-down'></i>") : Html.Raw("<i class='fa-solid fa-sort'></i>")))
                         </a>
                     </th>
                     <th>
-                        <a asp-action="ViewAll" asp-route-sortBy="@sortByCategory" asp-route-filterBy="@filterBy" asp-route-filterValue="@filterValue" asp-route-pageIndex="@pageIndex" class="text-black">
+                        <a asp-action="ViewAll" asp-route-sortBy="@sortByCategory" asp-route-filterBy="@filterBy" asp-route-filterValue="@filterValue" asp-route-pageIndex="@pageIndex" asp-route-search="@search"class="text-black">
                             @Html.DisplayNameFor(model => model.First().CategoryType)
                             @(sortBy == "category" ? Html.Raw("<i class='fa-solid fa-sort-up'></i>") : (sortBy == "category_desc" ? Html.Raw("<i class='fa-solid fa-sort-down'></i>") : Html.Raw("<i class='fa-solid fa-sort'></i>")))
                         </a>
                     </th>
                     <th>
-                        <a asp-action="ViewAll" asp-route-sortBy="@sortByPriority" asp-route-filterBy="@filterBy" asp-route-filterValue="@filterValue" asp-route-pageIndex="@pageIndex" class="text-black">
+                        <a asp-action="ViewAll" asp-route-sortBy="@sortByPriority" asp-route-filterBy="@filterBy" asp-route-filterValue="@filterValue" asp-route-pageIndex="@pageIndex" asp-route-search="@search" class="text-black">
                             @Html.DisplayNameFor(model => model.First().PriorityType)
                             @(sortBy == "priority" ? Html.Raw("<i class='fa-solid fa-sort-up'></i>") : (sortBy == "priority_desc" ? Html.Raw("<i class='fa-solid fa-sort-down'></i>") : Html.Raw("<i class='fa-solid fa-sort'></i>")))
                         </a>
                     </th>
                     <th>
-                        <a asp-action="ViewAll" asp-route-sortBy="@sortByStatus" asp-route-filterBy="@filterBy" asp-route-filterValue="@filterValue" asp-route-pageIndex="@pageIndex" class="text-black">
+                        <a asp-action="ViewAll" asp-route-sortBy="@sortByStatus" asp-route-filterBy="@filterBy" asp-route-filterValue="@filterValue" asp-route-pageIndex="@pageIndex" asp-route-search="@search" class="text-black">
                             @Html.DisplayNameFor(model => model.First().StatusType)
                             @(sortBy == "status" ? Html.Raw("<i class='fa-solid fa-sort-up'></i>") : (sortBy == "status_desc" ? Html.Raw("<i class='fa-solid fa-sort-down'></i>") : Html.Raw("<i class='fa-solid fa-sort'></i>")))
                         </a>
                     </th>
                     <th>
-                        @Html.DisplayNameFor(model => model.First().Attachment)
+                        Assignation
                     </th>
                     <th></th>
                 </tr>
@@ -177,13 +197,27 @@
                                 </span>
                             </td>
                             <td>
-                                @if (item.Attachment != null)
+                                @if (item.TicketAssignment != null)
                                 {
-                                    <a href="@Url.Action("DownloadAttachment", "Ticket", new { id = item.TicketId })">Download Attachment</a>
+                                    var teamName = item.TicketAssignment.Team?.Name;
+                                    var agentName = item.TicketAssignment.Agent?.Name;
+
+                                    if (teamName != null)
+                                    {
+                                        @teamName
+                                    }
+                                    if (teamName != null && agentName != null)
+                                    {
+                                        <text> | </text>
+                                    }
+                                    if (agentName != null)
+                                    {
+                                        @agentName
+                                    }
                                 }
                                 else
                                 {
-                                    @:No attachment
+                                    @:N/A
                                 }
                             </td>
                             <td>
@@ -223,19 +257,19 @@
                 @if (Model.HasPreviousPage)
                 {
                     <li class="page-item">
-                        <a class="page-link" asp-action="ViewAll" asp-route-pageIndex="@(Model.PageIndex - 1)" asp-route-sortBy="@sortBy" asp-route-filterBy="@filterBy" asp-route-filterValue="@filterValue">Previous</a>
+                        <a class="page-link" asp-action="ViewAll" asp-route-pageIndex="@(Model.PageIndex - 1)" asp-route-sortBy="@sortBy" asp-route-filterBy="@filterBy" asp-route-filterValue="@filterValue" asp-route-search="@search">Previous</a>
                     </li>
                 }
                 @for (int i = 1; i <= Model.TotalPages; i++)
                 {
                     <li class="page-item @(i == Model.PageIndex ? "active" : "")">
-                        <a class="page-link" asp-action="ViewAll" asp-route-pageIndex="@i" asp-route-sortBy="@sortBy" asp-route-filterBy="@filterBy" asp-route-filterValue="@filterValue">@i</a>
+                        <a class="page-link" asp-action="ViewAll" asp-route-pageIndex="@i" asp-route-sortBy="@sortBy" asp-route-filterBy="@filterBy" asp-route-filterValue="@filterValue" asp-route-search="@search">@i</a>
                     </li>
                 }
                 @if (Model.HasNextPage)
                 {
                     <li class="page-item">
-                        <a class="page-link" asp-action="ViewAll" asp-route-pageIndex="@(Model.PageIndex + 1)" asp-route-sortBy="@sortBy" asp-route-filterBy="@filterBy" asp-route-filterValue="@filterValue">Next</a>
+                        <a class="page-link" asp-action="ViewAll" asp-route-pageIndex="@(Model.PageIndex + 1)" asp-route-sortBy="@sortBy" asp-route-filterBy="@filterBy" asp-route-filterValue="@filterValue" asp-route-search="@search">Next</a>
                     </li>
                 }
             </ul>

--- a/ASI.Basecode.WebApp/Views/Ticket/ViewTicket.cshtml
+++ b/ASI.Basecode.WebApp/Views/Ticket/ViewTicket.cshtml
@@ -8,6 +8,7 @@
     await Html.RenderPartialAsync("_UpdateTrackingModal", Model);
     await Html.RenderPartialAsync("_ReopenTicketModal", Model);
     await Html.RenderPartialAsync("_UpdateAssignmentModal", Model);
+    await Html.RenderPartialAsync("_UpdateCategoryModal", Model);
     await Html.RenderPartialAsync("_ConfirmationModal");
 }
 
@@ -21,12 +22,36 @@
     {
         if (Model.StatusType.StatusName != "Resolved" && Model.StatusType.StatusName != "Closed")
         {
-            <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#updateTrackingModal">
-                Update Tracking
-            </button>
-            <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#updateAssignmentModal">
-                Update Assignment
-            </button>
+            if (!User.IsInRole("Admin") && (Model.TicketAssignment?.AgentId == null || Model.TicketAssignment?.AgentId == ViewBag.UserId))
+            {
+                <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#updateTrackingModal">
+                    Update Status/Priority
+                </button>
+                <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#updateAssignmentModal">
+                    Update Assignment
+                </button>
+                if(Model.TicketAssignment == null)
+                {
+                    <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#updateCategoryModal">
+                        Update Category
+                    </button>
+                }
+            }
+            else if (User.IsInRole("Admin"))
+            {
+                <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#updateTrackingModal">
+                    Update Tracking
+                </button>
+                <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#updateAssignmentModal">
+                    Update Assignment
+                </button>
+                if (Model.TicketAssignment == null)
+                {
+                    <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#updateCategoryModal">
+                        Update Category
+                    </button>
+                }
+            }
         }
     } 
     else
@@ -34,11 +59,11 @@
         if(Model.StatusType.StatusName != "Resolved" && Model.StatusType.StatusName != "Closed")
         {
             <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#updateTrackingModal">
-                Update Ticket
+                Update Tracking
             </button>
 
             <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#editTicketModal">
-                Edit Ticket
+                Update Ticket
             </button>
         }
         if (Model.StatusType.StatusName == "Closed")
@@ -202,6 +227,7 @@
         var addCommentUrl = '@Url.Action("AddComment", "Ticket")';
         var deleteCommentUrl = '@Url.Action("DeleteComment", "Ticket")';
         var ticketId = '@Model.TicketId';
+        var currentUserId = '@ViewBag.UserId';
 
         $('#teamId').change(function () {
             var selectedTeamMembers = $('#teamId option:selected').data('team-members');
@@ -227,8 +253,11 @@
                     agentDropdown.append(`<option value="no_agent">-- Select Agent: ${selectedTeamMembers.length} Available --</option>`);
                 }
 
+                selectedTeamMembers.sort((a, b) => (a.UserId === currentUserId ? -1 : (b.UserId === currentUserId ? 1 : 0)));
+
                 selectedTeamMembers.forEach(function (member) {
-                    agentDropdown.append('<option value="' + member.UserId + '">' + member.UserName + '</option>');
+                    var optionText = member.UserId == currentUserId ? member.UserName + ' (me)' : member.UserName;
+                    agentDropdown.append('<option value="' + member.UserId + '">' + optionText + '</option>');
                 });
 
                 agentDropdown.prop('disabled', false);
@@ -243,9 +272,6 @@
 
         $('#teamId').trigger('change');
     </script>
-
-
-
     <script src="~/js/comment.js"></script>
     <script src="~/js/feedback.js"></script>
     <script src="~/js/toastrNotification.js"></script>

--- a/ASI.Basecode.WebApp/Views/Ticket/_CreateTicketModal.cshtml
+++ b/ASI.Basecode.WebApp/Views/Ticket/_CreateTicketModal.cshtml
@@ -48,8 +48,9 @@
 
                     <div class="form-group">
                         <label asp-for="IssueDescription" class="control-label"></label>
-                        <textarea asp-for="IssueDescription" class="form-control"></textarea>
+                        <textarea asp-for="IssueDescription" id="issueDescription" class="form-control"></textarea>
                         <span asp-validation-for="IssueDescription" class="text-danger"></span>
+                        <span id="remainingDescriptionChars" class="text-muted">800 characters remaining</span>
                     </div>
 
                     <div class="form-group">

--- a/ASI.Basecode.WebApp/Views/Ticket/_EditTicketModal.cshtml
+++ b/ASI.Basecode.WebApp/Views/Ticket/_EditTicketModal.cshtml
@@ -22,8 +22,9 @@
                     </div>
                     <div class="form-group">
                         <label asp-for="IssueDescription" class="control-label"></label>
-                        <textarea asp-for="IssueDescription" class="form-control"></textarea>
+                        <textarea asp-for="IssueDescription" id="issueDescription" class="form-control"></textarea>
                         <span asp-validation-for="IssueDescription" class="text-danger"></span>
+                        <span id="remainingDescriptionChars" class="text-muted">800 characters remaining</span>
                     </div>
                     <div class="form-group">
                         <div id="attachmentDetails" style="display: @(Model.Attachment != null ? "block" : "none")">

--- a/ASI.Basecode.WebApp/Views/Ticket/_FeedbackModal.cshtml
+++ b/ASI.Basecode.WebApp/Views/Ticket/_FeedbackModal.cshtml
@@ -28,6 +28,7 @@
                         <label for="content" class="font-weight-bold">Comment</label>
                         <textarea class="form-control" id="content" name="FeedbackContent" rows="3"></textarea>
                         <span id="contentError" class="text-danger" style="display: none;">Please provide feedback content.</span>
+                        <span id="remainingFeedbackChars" class="text-muted">800 characters remaining</span>
                     </div>
                 </form>
             </div>

--- a/ASI.Basecode.WebApp/Views/Ticket/_UpdateAssignmentModal.cshtml
+++ b/ASI.Basecode.WebApp/Views/Ticket/_UpdateAssignmentModal.cshtml
@@ -14,13 +14,13 @@
                     <div class="form-group">
                         <label for="teamId" class="control-label">Team</label>
                         <select asp-for="Team.TeamId" id="teamId" class="form-control">
-                            <option value="no_team" data-team-members='@Html.Raw(Newtonsoft.Json.JsonConvert.SerializeObject(Model.AgentsWithNoTeam.Select(tm => new { tm.UserId, UserName = tm.Name })))'>@(string.IsNullOrEmpty(Model.Team?.TeamId) ? "-- No Team --" : "-- Unassign --")</option>
+                            <option value="no_team" data-team-members='@Html.Raw(Newtonsoft.Json.JsonConvert.SerializeObject(Model.AgentsWithNoTeam?.Select(tm => new { tm.UserId, UserName = tm.Name })))'>@(string.IsNullOrEmpty(Model.Team?.TeamId) ? "-- No Team --" : "-- Unassign --")</option>
                             @foreach (var teamGroup in Model.Teams.OrderBy(t => t.Specialization.CategoryName).GroupBy(t => t.Specialization.CategoryName))
                             {
                                 <optgroup label="@teamGroup.Key">
                                     @foreach (var team in teamGroup)
                                     {
-                                        <option value="@team.TeamId" data-team-members='@Html.Raw(Newtonsoft.Json.JsonConvert.SerializeObject(team.TeamMembers.Select(tm => new { tm.UserId, UserName = tm.User.Name })))'>
+                                        <option value="@team.TeamId" data-team-members='@Html.Raw(Newtonsoft.Json.JsonConvert.SerializeObject(team.TeamMembers?.Select(tm => new { tm.UserId, UserName = tm.User.Name })))'>
                                             @team.Name
                                         </option>
                                     }

--- a/ASI.Basecode.WebApp/Views/Ticket/_UpdateCategoryModal.cshtml
+++ b/ASI.Basecode.WebApp/Views/Ticket/_UpdateCategoryModal.cshtml
@@ -1,0 +1,32 @@
+﻿@model ASI.Basecode.Services.ServiceModels.TicketViewModel
+
+<div class="modal fade" id="updateCategoryModal" tabindex="-1" role="dialog" aria-labelledby="updateCategoryModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title font-weight-bold" id="updateCategoryModalLabel">TICKET ID #@Model.TicketId</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body">
+                <form id="updateCategoryForm">
+                    <div class="form-group">
+                        <label for="categoryId">Category</label>
+                        <select asp-for="CategoryTypeId" id="categoryId" class="form-control">
+                            @foreach (var category in Model.CategoryTypes)
+                            {
+                                <option value="@category.CategoryTypeId">@category.CategoryName</option>
+                            }
+                        </select>
+                    </div>
+                    <input type="hidden" id="ticketId" value="@Model.TicketId" />
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-primary" onclick="validateCategory('@Model.CategoryTypeId')">Save changes</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/ASI.Basecode.WebApp/wwwroot/js/feedback.js
+++ b/ASI.Basecode.WebApp/wwwroot/js/feedback.js
@@ -9,6 +9,16 @@
     }
 });
 
+document.addEventListener('DOMContentLoaded', function () {
+    var contentTextarea = document.getElementById('content');
+    var remainingCharsSpan = document.getElementById('remainingFeedbackChars');
+
+    contentTextarea.addEventListener('keyup', function () {
+        var remaining = 800 - this.value.length;
+        remainingCharsSpan.textContent = remaining + ' characters remaining';
+    });
+});
+
 var formData;
 function validateFeedback() {
     formData = {

--- a/ASI.Basecode.WebApp/wwwroot/js/ticket.js
+++ b/ASI.Basecode.WebApp/wwwroot/js/ticket.js
@@ -9,6 +9,20 @@
     }
 });
 
+document.addEventListener('DOMContentLoaded', function () {
+    var contentTextarea = document.getElementById('issueDescription');
+    var remainingCharsSpan = document.getElementById('remainingDescriptionChars');
+
+    function updateRemainingChars() {
+        var remaining = 800 - contentTextarea.value.length;
+        remainingCharsSpan.textContent = remaining + ' characters remaining';
+    }
+
+    updateRemainingChars();
+
+    contentTextarea.addEventListener('keyup', updateRemainingChars);
+});
+
 $('#createTicketModal').on('hidden.bs.modal', function () {
     toastr.info("Create cancelled, no changes were made");
 });

--- a/ASI.Basecode.WebApp/wwwroot/js/ticket.js
+++ b/ASI.Basecode.WebApp/wwwroot/js/ticket.js
@@ -31,7 +31,6 @@ function submitCreateTicket() {
         contentType: false,
         success: function (response) {
             if (response.success) {
-                $('#createTicketModal').modal('hide');
                 location.reload();
             } else {
                 var errorMessage = response.error || "An error occurred.";
@@ -84,7 +83,6 @@ function submitEditTicket() {
         contentType: false,
         success: function (response) {
             if (response.success) {
-                $('#editTicketModal').modal('hide');
                 location.reload();
             } else {
                 var errorMessage = response.error || "An error occurred.";
@@ -95,6 +93,51 @@ function submitEditTicket() {
             var errorMessage = xhr.responseJSON && xhr.responseJSON.error ? xhr.responseJSON.error : "An unexpected error occurred.";
             toastr.error(errorMessage);
             $('#editTicketModal').modal('hide');
+        }
+    });
+}
+
+var categoryId;
+function validateCategory(currentCategoryId) {
+    categoryId = $('#categoryId').val();
+
+    if (categoryId === currentCategoryId) {
+        toastr.info("Category remains unchanged.");
+    } else {
+        $('#updateCategoryModal').modal('hide');
+        setTimeout(function () {
+            var message = 'Changing the category might result in you losing access to this ticket';
+            displayConfirmationModal(saveCategory, message, 'updateCategoryModal');
+        }, 250);
+    }
+}
+
+function saveCategory() {
+    var ticketId = $('#ticketId').val();
+
+    $.ajax({
+        url: '/Ticket/Edit',
+        type: 'POST',
+        data: {
+            TicketId: ticketId,
+            CategoryTypeId: categoryId,
+        },
+        success: function (response) {
+            if (response.success) {
+                categoryId = null;
+                location.reload();
+            } else {
+                categoryId = null;
+                var errorMessage = response.error || "An error occurred.";
+                toastr.error(errorMessage);
+                $('#confirmationModal').modal('hide');
+            }
+        },
+        error: function (xhr, status, error) {
+            var errorMessage = xhr.responseJSON && xhr.responseJSON.error ? xhr.responseJSON.error : "An unexpected error occurred.";
+            categoryId = null;
+            toastr.error(errorMessage);
+            $('#confirmationModal').modal('hide');
         }
     });
 }
@@ -136,7 +179,6 @@ function saveTracking() {
         success: function (response) {
             if (response.success) {
                 statusId = null;
-                $('#updateTrackingModal').modal('hide');
                 location.reload();
             } else {
                 statusId = null;
@@ -169,7 +211,6 @@ $('#saveAssignmentBtn').click(function () {
         }),
         success: function (response) {
             if (response.success) {
-                $('#updateAssignmentModal').modal('hide');
                 location.reload();
             } else {
                 var errorMessage = response.error || "An error occurred.";


### PR DESCRIPTION
Ticket modifications
- changed Edit ticket to Update ticket, per PM consultation
- changed default UpdatedDate to now upon ticket creation, per PM consultation
- enabled ticket self-assignment, as long as ticket category is "Others" or the same as agent's team specialization
- enabled changing category for admin and agents
- restricted ticket viewing and access according to ticket category, agent's team specialization, or ticket assignments
- closed tickets now inaccessible to users that didnt create it
- add character counting to text field with limit, as per PM consultation
- fixed the logic for ticket viewing
- fixed sorting and filtering behavior
- added search by ticket subject
- removed attachment, replaced with assignation in ViewAll

Team views modification
- fixed sorting and filtering behavior